### PR TITLE
Implement ISBN manual input page (#9)

### DIFF
--- a/docs/9-isbn-manual-input/tasks.md
+++ b/docs/9-isbn-manual-input/tasks.md
@@ -2,13 +2,13 @@
 
 ## Tasks
 
-- [ ] Task 1: IsbnValidator に getValidationMessage メソッド追加
+- [x] Task 1: IsbnValidator に getValidationMessage メソッド追加
   - 入力途中は null（エラー非表示）
   - 有効な ISBN は null
   - 無効な ISBN はエラーメッセージ文字列を返す
   - テスト: 各パターンのバリデーションメッセージ
 
-- [ ] Task 2: IsbnInputPage の作成
+- [x] Task 2: IsbnInputPage の作成
   - TextEditingController + リアルタイムバリデーション
   - 有効時の表示（「有効なISBNです」）
   - エラー時の表示（エラーメッセージ）
@@ -16,6 +16,6 @@
   - バーコードスキャンへの遷移ボタン
   - テスト: 各状態のUI表示、ボタン有効/無効、遷移
 
-- [ ] Task 3: ルーティングの追加
+- [x] Task 3: ルーティングの追加
   - app_router.dart に `/isbn-input` ルートを追加
   - テスト: ルーティングテスト

--- a/lib/presentation/pages/barcode_scanner_page.dart
+++ b/lib/presentation/pages/barcode_scanner_page.dart
@@ -89,7 +89,7 @@ class _BarcodeScannerPageState extends State<BarcodeScannerPage> {
                     .invokeMethod<void>('openAppSettings');
               },
               onManualInput: () {
-                // TODO: Issue #9 で手動入力画面へ遷移
+                context.go('/isbn-input');
               },
             )
           : Column(
@@ -123,7 +123,7 @@ class _BarcodeScannerPageState extends State<BarcodeScannerPage> {
                       width: double.infinity,
                       child: OutlinedButton.icon(
                         onPressed: () {
-                          // TODO: Issue #9 で手動入力画面へ遷移
+                          context.go('/isbn-input');
                         },
                         icon: const Icon(Icons.keyboard),
                         label: const Text('ISBNを手動入力する'),

--- a/lib/presentation/pages/isbn_input_page.dart
+++ b/lib/presentation/pages/isbn_input_page.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:libcheck/domain/utils/isbn_validator.dart';
+
+class IsbnInputPage extends StatefulWidget {
+  const IsbnInputPage({super.key});
+
+  @override
+  State<IsbnInputPage> createState() => _IsbnInputPageState();
+}
+
+class _IsbnInputPageState extends State<IsbnInputPage> {
+  final _controller = TextEditingController();
+  String? _errorText;
+  bool _isValid = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_onChanged);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onChanged() {
+    final value = _controller.text;
+    final message = IsbnValidator.getValidationMessage(value);
+    final normalized = IsbnValidator.normalizeIsbn(value);
+    final isValid = normalized.isNotEmpty && IsbnValidator.isValidIsbn(value);
+
+    setState(() {
+      _errorText = message;
+      _isValid = isValid;
+    });
+  }
+
+  void _onSubmit() {
+    final isbn = IsbnValidator.normalizeIsbn(_controller.text);
+    context.go('/result/$isbn');
+  }
+
+  void _navigateToScan() {
+    context.go('/scan');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final normalized = IsbnValidator.normalizeIsbn(_controller.text);
+    final showValid = _isValid && _errorText == null && normalized.length >= 10;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('ISBN入力'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'ISBNを入力してください',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _controller,
+              keyboardType: TextInputType.number,
+              decoration: InputDecoration(
+                labelText: 'ISBN (13桁 または 10桁)',
+                border: const OutlineInputBorder(),
+                errorText: _errorText,
+              ),
+            ),
+            const SizedBox(height: 8),
+            if (showValid)
+              Text(
+                '有効なISBNです',
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              ),
+            const SizedBox(height: 8),
+            Text(
+              '書籍の裏表紙に記載されている13桁の数字を入力してください。',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _isValid ? _onSubmit : null,
+                child: const Text('検索する'),
+              ),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
+                onPressed: _navigateToScan,
+                child: const Text('バーコードスキャンへ'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/router/app_router.dart
+++ b/lib/presentation/router/app_router.dart
@@ -9,6 +9,7 @@ import 'package:libcheck/presentation/pages/library_management_page.dart';
 import 'package:libcheck/presentation/pages/history_placeholder_page.dart';
 import 'package:libcheck/presentation/pages/prefecture_selection_page.dart';
 import 'package:libcheck/presentation/pages/city_selection_page.dart';
+import 'package:libcheck/presentation/pages/isbn_input_page.dart';
 import 'package:libcheck/presentation/pages/library_list_page.dart';
 
 final routerProvider = Provider<GoRouter>((ref) {
@@ -69,6 +70,10 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/scan',
         builder: (context, state) => const BarcodeScannerPage(),
+      ),
+      GoRoute(
+        path: '/isbn-input',
+        builder: (context, state) => const IsbnInputPage(),
       ),
       GoRoute(
         path: '/result/:isbn',

--- a/test/presentation/pages/isbn_input_page_test.dart
+++ b/test/presentation/pages/isbn_input_page_test.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:libcheck/presentation/pages/isbn_input_page.dart';
+
+void main() {
+  group('IsbnInputPage', () {
+    late GoRouter router;
+
+    setUp(() {
+      router = GoRouter(
+        initialLocation: '/isbn-input',
+        routes: [
+          GoRoute(
+            path: '/isbn-input',
+            builder: (context, state) => const IsbnInputPage(),
+          ),
+          GoRoute(
+            path: '/result/:isbn',
+            builder: (context, state) => Scaffold(
+              appBar: AppBar(title: const Text('検索結果')),
+              body: Text('ISBN: ${state.pathParameters['isbn']}'),
+            ),
+          ),
+          GoRoute(
+            path: '/scan',
+            builder: (context, state) => Scaffold(
+              appBar: AppBar(title: const Text('バーコードスキャン')),
+            ),
+          ),
+        ],
+      );
+    });
+
+    Widget buildTestWidget() {
+      return ProviderScope(
+        child: MaterialApp.router(
+          routerConfig: router,
+        ),
+      );
+    }
+
+    testWidgets('AppBarに「ISBN入力」と表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(AppBar, 'ISBN入力'), findsOneWidget);
+    });
+
+    testWidgets('説明テキストが表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('ISBNを入力してください'), findsOneWidget);
+    });
+
+    testWidgets('ISBN入力フィールドが表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextField), findsOneWidget);
+    });
+
+    testWidgets('ヒントテキストが表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('書籍の裏表紙に記載されている13桁の数字を入力してください。'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('検索ボタンが表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('検索する'), findsOneWidget);
+    });
+
+    testWidgets('バーコードスキャンボタンが表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('バーコードスキャンへ'), findsOneWidget);
+    });
+
+    testWidgets('初期状態で検索ボタンが無効', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      final button = tester.widget<FilledButton>(find.widgetWithText(FilledButton, '検索する'));
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('入力途中ではエラーメッセージが表示されない', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '978410');
+      await tester.pump();
+
+      expect(find.text('有効なISBNです'), findsNothing);
+      expect(find.textContaining('チェックディジット'), findsNothing);
+    });
+
+    testWidgets('入力途中では検索ボタンが無効のまま', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '978410');
+      await tester.pump();
+
+      final button = tester.widget<FilledButton>(find.widgetWithText(FilledButton, '検索する'));
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('有効なISBN-13入力時に「有効なISBNです」と表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '9784873117584');
+      await tester.pump();
+
+      expect(find.text('有効なISBNです'), findsOneWidget);
+    });
+
+    testWidgets('有効なISBN-13入力時に検索ボタンが有効になる', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '9784873117584');
+      await tester.pump();
+
+      final button = tester.widget<FilledButton>(find.widgetWithText(FilledButton, '検索する'));
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('有効なISBN-10入力時に「有効なISBNです」と表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '4873117585');
+      await tester.pump();
+
+      expect(find.text('有効なISBNです'), findsOneWidget);
+    });
+
+    testWidgets('無効なISBN入力時にエラーメッセージが表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '9784873117585');
+      await tester.pump();
+
+      expect(find.text('ISBN-13 のチェックディジットが正しくありません'), findsOneWidget);
+    });
+
+    testWidgets('無効なISBN入力時に検索ボタンが無効', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '9784873117585');
+      await tester.pump();
+
+      final button = tester.widget<FilledButton>(find.widgetWithText(FilledButton, '検索する'));
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('有効なISBN入力後に検索ボタンで/result/:isbnへ遷移する', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '9784873117584');
+      await tester.pump();
+
+      await tester.tap(find.text('検索する'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('検索結果'), findsOneWidget);
+      expect(find.text('ISBN: 9784873117584'), findsOneWidget);
+    });
+
+    testWidgets('バーコードスキャンボタンで/scanへ遷移する', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('バーコードスキャンへ'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('バーコードスキャン'), findsOneWidget);
+    });
+
+    testWidgets('ハイフン付きISBN入力でも正しく動作する', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '978-4-87311-758-4');
+      await tester.pump();
+
+      expect(find.text('有効なISBNです'), findsOneWidget);
+    });
+
+    testWidgets('ハイフン付きISBN入力後の遷移でハイフンが除去される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '978-4-87311-758-4');
+      await tester.pump();
+
+      await tester.tap(find.text('検索する'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('ISBN: 9784873117584'), findsOneWidget);
+    });
+  });
+}

--- a/test/presentation/router/app_router_test.dart
+++ b/test/presentation/router/app_router_test.dart
@@ -279,5 +279,33 @@ void main() {
       expect(find.widgetWithText(AppBar, 'バーコードスキャン'), findsOneWidget);
     });
 
+    testWidgets('navigates to ISBN input page at /isbn-input',
+        (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          registeredLibraryRepositoryProvider
+              .overrideWithValue(FakeRegisteredLibraryRepository()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final router = container.read(routerProvider);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      router.go('/isbn-input');
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(AppBar, 'ISBN入力'), findsOneWidget);
+    });
+
   });
 }


### PR DESCRIPTION
## Summary

- ISBN手動入力ページを実装（Issue #9）
- リアルタイムISBNバリデーション付きの手動入力フォーム
- ISBN-10/ISBN-13両方をサポート
- バーコードスキャナーページのTODOコメントを実際のナビゲーションに置換（`/isbn-input`へ遷移）
- `/isbn-input` ルートをapp_routerに追加

## Changes

- `lib/presentation/pages/isbn_input_page.dart` - ISBN手動入力ページ（新規）
- `lib/presentation/router/app_router.dart` - `/isbn-input` ルート追加
- `lib/presentation/pages/barcode_scanner_page.dart` - TODOを実際のナビゲーションに置換
- `test/presentation/pages/isbn_input_page_test.dart` - 入力ページテスト（新規）
- `test/presentation/router/app_router_test.dart` - `/isbn-input` ルートテスト追加
- `docs/9-isbn-manual-input/tasks.md` - 全タスク完了

## Test plan

- [x] IsbnInputPage: 18テスト（タイトル表示、バリデーション、検索ボタン、ナビゲーション）
- [x] AppRouter: 11テスト（/isbn-inputルート含む全ルート）
- [x] BarcodeScannerPage: 3テスト（手動入力ボタン動作確認）
- [x] 合計32テスト全てパス ✅

🤖 Generated with [Claude Code](https://claude.ai/code)