### PR TITLE
Add barcode scan and ISBN input buttons to home page

### DIFF
--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:libcheck/presentation/providers/app_providers.dart';
 
@@ -15,8 +16,32 @@ class HomePage extends ConsumerWidget {
         title: Text(title),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
-      body: const Center(
-        child: Text('Welcome to LibCheck'),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              FilledButton.icon(
+                onPressed: () => context.go('/scan'),
+                icon: const Icon(Icons.qr_code_scanner),
+                label: const Text('バーコードでスキャン'),
+                style: FilledButton.styleFrom(
+                  minimumSize: const Size(double.infinity, 56),
+                ),
+              ),
+              const SizedBox(height: 16),
+              OutlinedButton.icon(
+                onPressed: () => context.go('/isbn-input'),
+                icon: const Icon(Icons.keyboard),
+                label: const Text('ISBNを入力'),
+                style: OutlinedButton.styleFrom(
+                  minimumSize: const Size(double.infinity, 56),
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/test/presentation/pages/home_page_test.dart
+++ b/test/presentation/pages/home_page_test.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:libcheck/presentation/pages/home_page.dart';
 import 'package:libcheck/presentation/providers/app_providers.dart';
 
 void main() {
   group('HomePage', () {
-    testWidgets('renders AppBar with title from appTitleProvider', (tester) async {
+    testWidgets('renders AppBar with title from appTitleProvider',
+        (tester) async {
       await tester.pumpWidget(
         const ProviderScope(
           child: MaterialApp(
@@ -32,7 +34,8 @@ void main() {
       expect(find.byType(Scaffold), findsOneWidget);
     });
 
-    testWidgets('displays overridden title when provider is overridden', (tester) async {
+    testWidgets('displays overridden title when provider is overridden',
+        (tester) async {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -46,6 +49,96 @@ void main() {
 
       expect(find.text('Test App'), findsOneWidget);
       expect(find.text('LibCheck'), findsNothing);
+    });
+
+    testWidgets('バーコードスキャンボタンが表示される', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: HomePage(),
+          ),
+        ),
+      );
+
+      expect(find.text('バーコードでスキャン'), findsOneWidget);
+      expect(find.byIcon(Icons.qr_code_scanner), findsOneWidget);
+    });
+
+    testWidgets('ISBN手動入力ボタンが表示される', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: HomePage(),
+          ),
+        ),
+      );
+
+      expect(find.text('ISBNを入力'), findsOneWidget);
+      expect(find.byIcon(Icons.keyboard), findsOneWidget);
+    });
+
+    testWidgets('バーコードスキャンボタンで/scanへ遷移する', (tester) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const HomePage(),
+          ),
+          GoRoute(
+            path: '/scan',
+            builder: (context, state) => Scaffold(
+              appBar: AppBar(title: const Text('バーコードスキャン')),
+            ),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp.router(
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('バーコードでスキャン'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('バーコードスキャン'), findsOneWidget);
+    });
+
+    testWidgets('ISBN手動入力ボタンで/isbn-inputへ遷移する', (tester) async {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const HomePage(),
+          ),
+          GoRoute(
+            path: '/isbn-input',
+            builder: (context, state) => Scaffold(
+              appBar: AppBar(title: const Text('ISBN入力')),
+            ),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp.router(
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('ISBNを入力'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('ISBN入力'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

- ホーム画面にバーコードスキャンとISBN手動入力のアクションボタンを追加
- Phase 3の全機能（Issue #8, #9, #10）をホーム画面から利用可能に統合
- プレースホルダーテキストを実際のアクションボタンに置換

## Changes

- `lib/presentation/pages/home_page.dart` - スキャン・入力ボタン追加
- `test/presentation/pages/home_page_test.dart` - 4テスト追加（ボタン表示、ナビゲーション）

## Test plan

- [x] 既存テスト3つ維持（AppBar、Scaffold、プロバイダーオーバーライド）
- [x] バーコードスキャンボタン表示テスト
- [x] ISBN手動入力ボタン表示テスト
- [x] /scanへのナビゲーションテスト
- [x] /isbn-inputへのナビゲーションテスト
- [x] 全7テストパス ✅

🤖 Generated with [Claude Code](https://claude.ai/code)