### PR TITLE
UIデザインの仕上げ

### DIFF
--- a/docs/31-ui-design-polish/design.md
+++ b/docs/31-ui-design-polish/design.md
@@ -1,0 +1,33 @@
+# Issue #31: UIデザインの仕上げ — 設計
+
+## Architecture Overview
+
+テーマ定義を `app.dart` に集約し、デザインガイドラインの配色を適用する。個別画面のスタイル個別指定を除去して統一する。
+
+## Component Design
+
+### テーマ設定 (`app.dart`)
+
+```dart
+ThemeData(
+  colorScheme: ColorScheme.fromSeed(
+    seedColor: const Color(0xFF00796B),  // Teal
+  ),
+  useMaterial3: true,
+)
+```
+
+### 修正対象
+
+| ファイル | 修正内容 |
+|---------|----------|
+| `app.dart` | seedColor を `deepPurple` → `Teal (#00796B)` に変更 |
+| `home_page.dart` | AppBar の `backgroundColor: inversePrimary` を除去、ウェルカムUI追加 |
+
+## Data Flow
+
+テーマ変更のみのため、データフローの変更なし。
+
+## Domain Models
+
+変更なし。

--- a/docs/31-ui-design-polish/requirements.md
+++ b/docs/31-ui-design-polish/requirements.md
@@ -1,0 +1,30 @@
+# Issue #31: UIデザインの仕上げ — 要件定義
+
+## Problem Statement
+
+現状のアプリテーマは `Colors.deepPurple` をシードカラーとしたデフォルトテーマが使用されており、デザインガイドラインで定義された `Teal (#00796B)` ベースの配色が適用されていない。また、ホームページの AppBar に `inversePrimary` 背景色がハードコードされている等、全体的な統一感が不足している。
+
+## Requirements
+
+### Functional Requirements
+
+1. **テーマカラーの適用**: デザインガイドラインの Teal (#00796B) をプライマリカラーとしたカスタム `ColorScheme` を適用する
+2. **AppBar スタイルの統一**: 全画面の AppBar を統一した見た目にする（`inversePrimary` の個別指定を除去）
+3. **ホームページの改善**: アプリの顔となるホームページにアイコンやウェルカムメッセージを追加
+
+### Non-Functional Requirements
+
+1. デザインガイドラインに準拠した配色
+2. Material Design 3 に準拠
+
+## Constraints
+
+- 既存の機能を壊さない
+- 既存テストが全て通ること
+
+## Acceptance Criteria
+
+1. アプリ全体の Primary カラーが Teal (#00796B) になっている
+2. ホームページの AppBar が他画面と統一されている
+3. ホームページにアプリの説明やアイコンが表示されている
+4. 全テストが通ること

--- a/docs/31-ui-design-polish/tasks.md
+++ b/docs/31-ui-design-polish/tasks.md
@@ -1,0 +1,7 @@
+# Issue #31: UIデザインの仕上げ — タスク一覧
+
+## Implementation Tasks
+
+- [x] 1. `app.dart` のテーマカラーをデザインガイドラインの Teal に変更
+- [x] 2. `home_page.dart` の AppBar スタイル統一とウェルカムUI追加
+- [x] 3. 全テストの実行と flutter analyze の確認

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -13,7 +13,10 @@ class LibCheckApp extends ConsumerWidget {
     return MaterialApp.router(
       title: 'LibCheck',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFF00796B),
+        ),
+        useMaterial3: true,
       ),
       routerConfig: router,
     );

--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -14,7 +14,6 @@ class HomePage extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text(title),
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
       body: Center(
         child: Padding(
@@ -22,6 +21,17 @@ class HomePage extends ConsumerWidget {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
+              Icon(
+                Icons.menu_book,
+                size: 64,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                '図書館の蔵書をかんたん検索',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 32),
               FilledButton.icon(
                 onPressed: () => context.go('/scan'),
                 icon: const Icon(Icons.qr_code_scanner),

--- a/test/presentation/pages/home_page_test.dart
+++ b/test/presentation/pages/home_page_test.dart
@@ -51,6 +51,19 @@ void main() {
       expect(find.text('LibCheck'), findsNothing);
     });
 
+    testWidgets('displays welcome icon and description', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: HomePage(),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.menu_book), findsOneWidget);
+      expect(find.textContaining('図書館の蔵書'), findsOneWidget);
+    });
+
     testWidgets('バーコードスキャンボタンが表示される', (tester) async {
       await tester.pumpWidget(
         const ProviderScope(


### PR DESCRIPTION
## Summary

- Phase 5 の Issue #31: UIデザインの仕上げ
- テーマのシードカラーを `deepPurple` → `Teal (#00796B)` に変更（デザインガイドライン準拠）
- `useMaterial3: true` を明示
- ホームページの AppBar から `backgroundColor: inversePrimary` を除去し他画面と統一
- ホームページにウェルカムアイコン（`menu_book`）と説明テキストを追加

## Test plan

- [x] ホームページにウェルカムUI（アイコン・テキスト）が表示されるテスト追加
- [x] 全 318 テスト合格、flutter analyze 通過

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)