### PR TITLE
Fix barcode scanner error handling for non-permission errors

### DIFF
--- a/docs/36-fix-barcode-scanner-error-handling/design.md
+++ b/docs/36-fix-barcode-scanner-error-handling/design.md
@@ -1,0 +1,54 @@
+# Issue #36: バーコードスキャン画面のエラーハンドリング修正 — 設計
+
+## Architecture Overview
+
+`BarcodeScannerPage` のエラーハンドリングを改善し、エラー種別に応じて適切な UI を表示する。
+
+## Component Design
+
+### エラー状態の分類
+
+```mermaid
+stateDiagram-v2
+    [*] --> Starting: initState
+    Starting --> Running: start() 成功
+    Starting --> PermissionError: permissionDenied
+    Starting --> GeneralError: その他のエラー
+    Running --> Starting: 結果画面から復帰
+    GeneralError --> Starting: リトライ
+    PermissionError --> [*]: 設定を開く / ISBN手動入力
+    GeneralError --> [*]: ISBN手動入力
+```
+
+### 変更対象ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `lib/presentation/pages/barcode_scanner_page.dart` | エラーコード判別、状態管理の改善 |
+| `test/presentation/pages/barcode_scanner_page_test.dart` | エラーパターン別のテスト追加 |
+
+### BarcodeScannerPage の状態管理変更
+
+**Before:**
+- `bool _hasPermissionError` — 全エラーを一括管理
+
+**After:**
+- `MobileScannerErrorCode? _errorCode` — エラーコードを保持し、null なら正常状態
+
+### UI 分岐
+
+- `_errorCode == null` → カメラプレビュー表示
+- `_errorCode == permissionDenied` → 既存の `CameraPermissionErrorWidget`
+- `_errorCode != null && _errorCode != permissionDenied` → リトライ可能なエラー画面（`ErrorStateWidget` を活用）
+
+## Data Flow
+
+1. `initState` → `_startCamera()` 呼び出し
+2. `_startCamera()` 内で `_controller.start()` を await
+3. 成功 → `_errorCode = null`
+4. 失敗 → `_errorCode = exception.errorCode` をセット
+5. リトライ → `_errorCode = null` にリセットして `_startCamera()` を再呼び出し
+
+## Domain Models
+
+変更なし。

--- a/docs/36-fix-barcode-scanner-error-handling/requirements.md
+++ b/docs/36-fix-barcode-scanner-error-handling/requirements.md
@@ -1,0 +1,30 @@
+# Issue #36: バーコードスキャン画面のエラーハンドリング修正 — 要件定義
+
+## Problem Statement
+
+バーコードスキャン画面で `MobileScannerController.start()` のエラーをすべてカメラ権限エラーとして扱っているため、カメラ権限が許可済みでもプラットフォーム起因の一般エラーが発生すると「設定を開く」画面が表示されてしまう。
+
+## Requirements
+
+### Functional Requirements
+
+1. カメラ権限が拒否された場合のみ、権限エラー画面（「設定を開く」ボタン）を表示する
+2. 権限拒否以外のエラー（`genericError`、`controllerAlreadyInitialized` 等）の場合は、リトライ可能なエラー画面を表示する
+3. 結果画面からの復帰時にカメラ再起動が失敗した場合も、適切にエラーハンドリングする
+
+### Non-Functional Requirements
+
+1. 既存のカメラ権限エラー画面の見た目は変更しない
+2. テストで各エラーパターンを検証できる
+
+## Constraints
+
+- `mobile_scanner` パッケージ v6.0.11 の API に準拠する
+- `MobileScannerException` と `MobileScannerErrorCode` を利用してエラー種別を判別する
+
+## Acceptance Criteria
+
+1. カメラ権限拒否時に「設定を開く」画面が表示される
+2. 権限拒否以外のエラー時にリトライボタン付きのエラー画面が表示される
+3. リトライボタンを押すとカメラ起動を再試行する
+4. 全テストが通る

--- a/docs/36-fix-barcode-scanner-error-handling/tasks.md
+++ b/docs/36-fix-barcode-scanner-error-handling/tasks.md
@@ -1,0 +1,7 @@
+# Issue #36: バーコードスキャン画面のエラーハンドリング修正 — タスク一覧
+
+## Implementation Tasks
+
+- [x] 1. `BarcodeScannerPage` のエラーハンドリングを改善し、エラーコード別に UI を分岐する
+- [x] 2. テストを追加・修正する
+- [x] 3. 全テスト実行と flutter analyze の確認

--- a/lib/presentation/pages/barcode_scanner_page.dart
+++ b/lib/presentation/pages/barcode_scanner_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 import 'package:libcheck/domain/utils/isbn_validator.dart';
+import 'package:libcheck/presentation/widgets/camera_error_widget.dart';
 import 'package:libcheck/presentation/widgets/camera_permission_error_widget.dart';
 import 'package:libcheck/presentation/widgets/scan_overlay_widget.dart';
 
@@ -18,19 +19,32 @@ class _BarcodeScannerPageState extends State<BarcodeScannerPage> {
   late final MobileScannerController _controller;
   bool _isFlashOn = false;
   bool _isProcessing = false;
-  bool _hasPermissionError = false;
+  MobileScannerErrorCode? _errorCode;
 
   @override
   void initState() {
     super.initState();
     _controller = MobileScannerController();
-    _controller.start().then((_) {}).catchError((error) {
+    _startCamera();
+  }
+
+  Future<void> _startCamera() async {
+    try {
+      await _controller.start();
+    } on MobileScannerException catch (e) {
       if (mounted) {
         setState(() {
-          _hasPermissionError = true;
+          _errorCode = e.errorCode;
         });
       }
+    }
+  }
+
+  void _retryCamera() {
+    setState(() {
+      _errorCode = null;
     });
+    _startCamera();
   }
 
   @override
@@ -61,7 +75,7 @@ class _BarcodeScannerPageState extends State<BarcodeScannerPage> {
     context.push('/result/$isbn').then((_) {
       if (mounted) {
         _isProcessing = false;
-        _controller.start();
+        _startCamera();
       }
     });
   }
@@ -73,30 +87,41 @@ class _BarcodeScannerPageState extends State<BarcodeScannerPage> {
     });
   }
 
+  Widget _buildErrorBody() {
+    if (_errorCode == MobileScannerErrorCode.permissionDenied) {
+      return CameraPermissionErrorWidget(
+        onOpenSettings: () {
+          const MethodChannel('flutter.baseflow.com/permissions/methods')
+              .invokeMethod<void>('openAppSettings');
+        },
+        onManualInput: () {
+          context.go('/isbn-input');
+        },
+      );
+    }
+    return CameraErrorWidget(
+      onRetry: _retryCamera,
+      onManualInput: () {
+        context.go('/isbn-input');
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('バーコードスキャン'),
         actions: [
-          if (!_hasPermissionError)
+          if (_errorCode == null)
             IconButton(
               icon: Icon(_isFlashOn ? Icons.flash_on : Icons.flash_off),
               onPressed: _toggleFlash,
             ),
         ],
       ),
-      body: _hasPermissionError
-          ? CameraPermissionErrorWidget(
-              onOpenSettings: () {
-                // プラットフォーム設定を開く
-                const MethodChannel('flutter.baseflow.com/permissions/methods')
-                    .invokeMethod<void>('openAppSettings');
-              },
-              onManualInput: () {
-                context.go('/isbn-input');
-              },
-            )
+      body: _errorCode != null
+          ? _buildErrorBody()
           : Column(
               children: [
                 Expanded(
@@ -106,11 +131,10 @@ class _BarcodeScannerPageState extends State<BarcodeScannerPage> {
                         controller: _controller,
                         onDetect: _onBarcodeDetected,
                         errorBuilder: (context, error, child) {
-                          // カメラ権限エラーの場合
                           WidgetsBinding.instance.addPostFrameCallback((_) {
-                            if (mounted && !_hasPermissionError) {
+                            if (mounted && _errorCode == null) {
                               setState(() {
-                                _hasPermissionError = true;
+                                _errorCode = error.errorCode;
                               });
                             }
                           });

--- a/lib/presentation/widgets/camera_error_widget.dart
+++ b/lib/presentation/widgets/camera_error_widget.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+class CameraErrorWidget extends StatelessWidget {
+  const CameraErrorWidget({
+    super.key,
+    required this.onRetry,
+    required this.onManualInput,
+  });
+
+  final VoidCallback onRetry;
+  final VoidCallback onManualInput;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.videocam_off_outlined,
+              size: 64,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'カメラの起動に失敗しました',
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'しばらくしてからもう一度お試しください。',
+              style: Theme.of(context).textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 32),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh),
+                label: const Text('再試行'),
+              ),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: onManualInput,
+                icon: const Icon(Icons.keyboard),
+                label: const Text('ISBNを手動入力する'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/presentation/widgets/camera_error_widget_test.dart
+++ b/test/presentation/widgets/camera_error_widget_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libcheck/presentation/widgets/camera_error_widget.dart';
+
+void main() {
+  group('CameraErrorWidget', () {
+    testWidgets('エラーメッセージが表示される', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CameraErrorWidget(
+              onRetry: () {},
+              onManualInput: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('カメラの起動に失敗しました'), findsOneWidget);
+    });
+
+    testWidgets('エラーアイコンが表示される', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CameraErrorWidget(
+              onRetry: () {},
+              onManualInput: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.videocam_off_outlined), findsOneWidget);
+    });
+
+    testWidgets('「再試行」ボタンが表示される', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CameraErrorWidget(
+              onRetry: () {},
+              onManualInput: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('再試行'), findsOneWidget);
+    });
+
+    testWidgets('「ISBNを手動入力する」ボタンが表示される', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CameraErrorWidget(
+              onRetry: () {},
+              onManualInput: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('ISBNを手動入力する'), findsOneWidget);
+    });
+
+    testWidgets('「再試行」ボタンをタップするとonRetryが呼ばれる', (tester) async {
+      var called = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CameraErrorWidget(
+              onRetry: () => called = true,
+              onManualInput: () {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('再試行'));
+      expect(called, isTrue);
+    });
+
+    testWidgets('「ISBNを手動入力する」ボタンをタップするとonManualInputが呼ばれる',
+        (tester) async {
+      var called = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CameraErrorWidget(
+              onRetry: () {},
+              onManualInput: () => called = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('ISBNを手動入力する'));
+      expect(called, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- バーコードスキャン画面で全エラーをカメラ権限エラーとして扱っていた問題を修正
- `MobileScannerErrorCode` を判別し、`permissionDenied` の場合のみ権限エラー画面を表示
- その他のエラー（`genericError` 等）にはリトライ可能な `CameraErrorWidget` を表示
- 結果画面からの復帰時のカメラ再起動エラーも適切にハンドリング

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `lib/presentation/pages/barcode_scanner_page.dart` | `_hasPermissionError: bool` → `_errorCode: MobileScannerErrorCode?` に変更、エラーコード別UI分岐、`_startCamera()` / `_retryCamera()` メソッド追加 |
| `lib/presentation/widgets/camera_error_widget.dart` | 新規：リトライ可能なカメラエラー画面ウィジェット |
| `test/presentation/widgets/camera_error_widget_test.dart` | 新規：CameraErrorWidget のテスト（6件） |

## Test plan
- [x] `flutter test` - 全324テスト通過
- [x] `flutter analyze` - 問題なし
- [ ] 実機でカメラ権限拒否時に「設定を開く」画面が表示されることを確認
- [ ] 実機でカメラ起動失敗時に「再試行」画面が表示されることを確認

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)