### PR TITLE
Hide reserve link for non-reservable statuses

### DIFF
--- a/docs/42-fix-reserve-link-by-status/design.md
+++ b/docs/42-fix-reserve-link-by-status/design.md
@@ -1,0 +1,71 @@
+# Issue #42: Design
+
+## Architecture Overview
+
+ドメイン層の `AvailabilityStatus` enum に `isReservable` プロパティを追加し、各ステータスが予約可能かどうかを判定する。UI層ではこのプロパティと `reserveUrl` の両方を条件として「予約する」リンクの表示を制御する。
+
+## Component Design
+
+### 1. `AvailabilityStatus` (ドメイン層)
+
+`isReservable` getter を追加する。
+
+```dart
+bool get isReservable => switch (this) {
+  available || inLibraryOnly || checkedOut || reserved || preparing => true,
+  notFound || closed || error || unknown => false,
+};
+```
+
+### 2. `LibraryAvailabilityCard` (UI層)
+
+個別図書館のステータスに基づいて予約リンクの表示を制御する。
+
+```mermaid
+flowchart TD
+    A[reserveUrl != null] --> B{個別図書館のステータス}
+    B -->|isReservable = true| C[「予約する」リンク表示]
+    B -->|isReservable = false| D[「予約する」リンク非表示]
+```
+
+**変更前:**
+```dart
+if (status.reserveUrl != null) ...[
+```
+
+**変更後:**
+```dart
+final libKeyStatus = status.statusForLibKey(library.libKey);
+// ...
+if (status.reserveUrl?.isNotEmpty ?? false && libKeyStatus.isReservable) ...[
+```
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Card as LibraryAvailabilityCard
+    participant Status as LibraryStatus
+    participant Enum as AvailabilityStatus
+
+    Card->>Status: statusForLibKey(libKey)
+    Status-->>Card: AvailabilityStatus (e.g. notFound)
+    Card->>Enum: isReservable
+    Enum-->>Card: false
+    Card->>Card: 「予約する」リンク非表示
+```
+
+## Domain Models
+
+### AvailabilityStatus (変更)
+
+```dart
+enum AvailabilityStatus {
+  // ... existing values ...
+
+  bool get isReservable => switch (this) {
+    available || inLibraryOnly || checkedOut || reserved || preparing => true,
+    notFound || closed || error || unknown => false,
+  };
+}
+```

--- a/docs/42-fix-reserve-link-by-status/requirements.md
+++ b/docs/42-fix-reserve-link-by-status/requirements.md
@@ -1,0 +1,40 @@
+# Issue #42: 蔵書なし・休館中等のステータスでも「予約する」リンクが表示される
+
+## Problem Statement
+
+`LibraryAvailabilityCard` で `reserveUrl` が存在すれば蔵書の状態に関わらず「予約する」リンクが表示される。蔵書がない、休館中、エラー等のステータスでは予約が意味をなさないため、リンクを非表示にすべき。
+
+## Requirements
+
+### Functional Requirements
+
+- 以下のステータスの場合のみ「予約する」リンクを表示する:
+  - `available`（貸出可能）
+  - `inLibraryOnly`（館内のみ）
+  - `checkedOut`（貸出中）
+  - `reserved`（予約中）
+  - `preparing`（準備中）
+- 以下のステータスの場合は「予約する」リンクを非表示にする:
+  - `notFound`（蔵書なし）
+  - `closed`（休館中）
+  - `error`（エラー）
+  - `unknown`（不明）
+
+### Non-Functional Requirements
+
+- ステータスに基づく予約可否の判定ロジックをドメイン層（`AvailabilityStatus`）に配置する
+
+## Constraints
+
+- `reserveUrl` はシステムレベルの値であり、個別図書館（libKey）レベルのステータスと組み合わせて判定する必要がある
+
+## Acceptance Criteria
+
+1. `AvailabilityStatus` に予約リンク表示可否を判定するプロパティが追加されること
+2. `LibraryAvailabilityCard` が個別図書館のステータスに基づいて「予約する」リンクの表示/非表示を制御すること
+3. 予約不可なステータスで `reserveUrl` が存在しても「予約する」リンクが表示されないこと
+4. 既存のテストがすべてパスすること
+
+## User Stories
+
+- ユーザーとして、蔵書がない図書館に「予約する」リンクが表示されないことで、無意味な予約操作を避けたい

--- a/docs/42-fix-reserve-link-by-status/tasks.md
+++ b/docs/42-fix-reserve-link-by-status/tasks.md
@@ -1,0 +1,7 @@
+# Issue #42: Implementation Tasks
+
+- [x] 1. `AvailabilityStatus.isReservable` のテストを追加する (`test/domain/models/availability_status_test.dart`)
+- [x] 2. `AvailabilityStatus` に `isReservable` プロパティを実装する (`lib/domain/models/availability_status.dart`)
+- [x] 3. `LibraryAvailabilityCard` のテストを追加・更新する（ステータスに基づく予約リンク表示制御）
+- [x] 4. `LibraryAvailabilityCard` で `isReservable` を使った条件分岐を実装する
+- [x] 5. 全テストが通ることを確認する

--- a/lib/domain/models/availability_status.dart
+++ b/lib/domain/models/availability_status.dart
@@ -21,6 +21,11 @@ enum AvailabilityStatus {
         unknown => 0,
       };
 
+  bool get isReservable => switch (this) {
+        available || inLibraryOnly || checkedOut || reserved || preparing => true,
+        notFound || closed || error || unknown => false,
+      };
+
   static AvailabilityStatus fromApiString(String value) => switch (value) {
         '貸出可' || '蔵書あり' => available,
         '館内のみ' => inLibraryOnly,

--- a/lib/presentation/widgets/library_availability_card.dart
+++ b/lib/presentation/widgets/library_availability_card.dart
@@ -45,7 +45,7 @@ class LibraryAvailabilityCard extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             AvailabilityStatusBadge(status: status.statusForLibKey(library.libKey)),
-            if (status.reserveUrl?.isNotEmpty ?? false) ...[
+            if ((status.reserveUrl?.isNotEmpty ?? false) && status.statusForLibKey(library.libKey).isReservable) ...[
               const SizedBox(height: 8),
               TextButton(
                 onPressed: () {

--- a/test/domain/models/availability_status_test.dart
+++ b/test/domain/models/availability_status_test.dart
@@ -78,6 +78,44 @@ void main() {
       });
     });
 
+    group('isReservable', () {
+      test('returns true for available', () {
+        expect(AvailabilityStatus.available.isReservable, isTrue);
+      });
+
+      test('returns true for inLibraryOnly', () {
+        expect(AvailabilityStatus.inLibraryOnly.isReservable, isTrue);
+      });
+
+      test('returns true for checkedOut', () {
+        expect(AvailabilityStatus.checkedOut.isReservable, isTrue);
+      });
+
+      test('returns true for reserved', () {
+        expect(AvailabilityStatus.reserved.isReservable, isTrue);
+      });
+
+      test('returns true for preparing', () {
+        expect(AvailabilityStatus.preparing.isReservable, isTrue);
+      });
+
+      test('returns false for notFound', () {
+        expect(AvailabilityStatus.notFound.isReservable, isFalse);
+      });
+
+      test('returns false for closed', () {
+        expect(AvailabilityStatus.closed.isReservable, isFalse);
+      });
+
+      test('returns false for error', () {
+        expect(AvailabilityStatus.error.isReservable, isFalse);
+      });
+
+      test('returns false for unknown', () {
+        expect(AvailabilityStatus.unknown.isReservable, isFalse);
+      });
+    });
+
     group('aggregate', () {
       test('returns the highest priority status', () {
         final statuses = [

--- a/test/presentation/widgets/library_availability_card_test.dart
+++ b/test/presentation/widgets/library_availability_card_test.dart
@@ -108,13 +108,13 @@ void main() {
       expect(find.text('貸出中'), findsOneWidget);
     });
 
-    testWidgets('displays reserve URL link when available', (tester) async {
+    testWidgets('displays reserve URL link when reservable status', (tester) async {
       await tester.pumpWidget(buildSubject(
         status: const LibraryStatus(
           systemId: 'Tokyo_Minato',
           status: AvailabilityStatus.available,
           reserveUrl: 'https://example.com/reserve',
-          libKeyStatuses: {},
+          libKeyStatuses: {'みなと': '貸出可'},
         ),
       ));
 
@@ -126,7 +126,7 @@ void main() {
         status: const LibraryStatus(
           systemId: 'Tokyo_Minato',
           status: AvailabilityStatus.available,
-          libKeyStatuses: {},
+          libKeyStatuses: {'みなと': '貸出可'},
         ),
       ));
 
@@ -139,11 +139,51 @@ void main() {
           systemId: 'Tokyo_Minato',
           status: AvailabilityStatus.available,
           reserveUrl: '',
-          libKeyStatuses: {},
+          libKeyStatuses: {'みなと': '貸出可'},
         ),
       ));
 
       expect(find.text('予約する'), findsNothing);
+    });
+
+    testWidgets('does not display reserve URL link when notFound status', (tester) async {
+      await tester.pumpWidget(buildSubject(
+        status: const LibraryStatus(
+          systemId: 'Tokyo_Minato',
+          status: AvailabilityStatus.available,
+          reserveUrl: 'https://example.com/reserve',
+          libKeyStatuses: {},
+        ),
+      ));
+
+      // libKey 'みなと' is not in libKeyStatuses, so status is notFound
+      expect(find.text('予約する'), findsNothing);
+    });
+
+    testWidgets('does not display reserve URL link when closed status', (tester) async {
+      await tester.pumpWidget(buildSubject(
+        status: const LibraryStatus(
+          systemId: 'Tokyo_Minato',
+          status: AvailabilityStatus.available,
+          reserveUrl: 'https://example.com/reserve',
+          libKeyStatuses: {'みなと': '休館中'},
+        ),
+      ));
+
+      expect(find.text('予約する'), findsNothing);
+    });
+
+    testWidgets('displays reserve URL link when checkedOut status', (tester) async {
+      await tester.pumpWidget(buildSubject(
+        status: const LibraryStatus(
+          systemId: 'Tokyo_Minato',
+          status: AvailabilityStatus.available,
+          reserveUrl: 'https://example.com/reserve',
+          libKeyStatuses: {'みなと': '貸出中'},
+        ),
+      ));
+
+      expect(find.text('予約する'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

- `AvailabilityStatus` enum に `isReservable` getter を追加し、予約可能なステータスを判定
- `LibraryAvailabilityCard` で個別図書館のステータスが `isReservable` の場合のみ「予約する」リンクを表示するよう修正
- 全9ステータスに対する `isReservable` テストを追加
- UIウィジェットのテストを追加・更新（notFound, closed, checkedOut ステータスのケース）

## Test plan

- [x] `AvailabilityStatus.isReservable` が予約可能ステータス（available, inLibraryOnly, checkedOut, reserved, preparing）で `true` を返すことを確認
- [x] `AvailabilityStatus.isReservable` が予約不可ステータス（notFound, closed, error, unknown）で `false` を返すことを確認
- [x] `LibraryAvailabilityCard` が予約可能ステータスで「予約する」リンクを表示することを確認
- [x] `LibraryAvailabilityCard` が予約不可ステータスで「予約する」リンクを非表示にすることを確認
- [x] 既存テストが全てパスすることを確認
- [ ] 実機で蔵書なし・休館中の図書館に「予約する」リンクが表示されないことを確認

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)