### PR TITLE
Validate URL scheme before launching reserve URL

### DIFF
--- a/docs/50-validate-reserve-url-scheme/design.md
+++ b/docs/50-validate-reserve-url-scheme/design.md
@@ -1,0 +1,36 @@
+# Issue #50: Design - reserveUrlのURLスキーム検証
+
+## Architecture Overview
+
+URLバリデーションをプレゼンテーション層のウィジェット内に追加する。URLの安全性検証はリンク表示判定とは別の関心事であるため、ヘルパーメソッドとして分離する。
+
+## Component Design
+
+### 変更対象
+
+#### `LibraryAvailabilityCard`
+
+```mermaid
+flowchart TD
+    A[予約するボタンタップ] --> B{URLスキーム検証}
+    B -->|http/https| C[launchUrl with externalApplication]
+    B -->|その他| D[SnackBarでエラー表示]
+    C --> E{launchUrl成功?}
+    E -->|成功| F[外部ブラウザ表示]
+    E -->|失敗| D
+```
+
+### 実装方針
+
+1. `_launchReserveUrl` メソッドを追加し、URLスキーム検証とエラーハンドリングを行う
+2. `Uri.parse` で解析し、`scheme` が `http` または `https` であることを確認
+3. `launchUrl` に `mode: LaunchMode.externalApplication` を明示
+4. `launchUrl` の失敗時にも `SnackBar` でフィードバックを表示
+
+## Data Flow
+
+変更なし（UI層のみの修正）。
+
+## Domain Models
+
+変更なし。

--- a/docs/50-validate-reserve-url-scheme/requirements.md
+++ b/docs/50-validate-reserve-url-scheme/requirements.md
@@ -1,0 +1,36 @@
+# Issue #50: reserveUrlのURLスキーム検証
+
+## Problem Statement
+
+`LibraryAvailabilityCard` で予約リンクをタップした際、カーリルAPIから取得した `reserveUrl` をバリデーションなしで `launchUrl` に渡している。APIレスポンスの改ざんやAPI不具合により不正なURLスキーム（`javascript:`, `file:`, `data:` 等）が含まれた場合、セキュリティリスクとなる。
+
+## Requirements
+
+### Functional Requirements
+
+- 予約リンクタップ時、URLスキームが `http` または `https` の場合のみ外部ブラウザで開く
+- 不正なスキームの場合はリンクを開かず、ユーザーに適切なフィードバックを表示する
+
+### Non-Functional Requirements
+
+- 既存の予約リンク表示ロジック（`isReservable` チェック、空文字列チェック）に影響を与えない
+- `LaunchMode.externalApplication` を明示して、アプリ内WebViewでの実行を防ぐ
+
+## Constraints
+
+- カーリルAPIの `reserveurl` フィールドは通常 `https://` で始まるURLを返す
+- `url_launcher` パッケージの `launchUrl` を使用する既存設計を維持する
+
+## Acceptance Criteria
+
+1. `https://` で始まるURLの場合、外部ブラウザで正常に開くこと
+2. `http://` で始まるURLの場合、外部ブラウザで正常に開くこと
+3. `javascript:` スキームのURLの場合、ブラウザを開かないこと
+4. `file:` スキームのURLの場合、ブラウザを開かないこと
+5. 不正なURLの場合、アプリがクラッシュしないこと
+6. `LaunchMode.externalApplication` が指定されていること
+
+## User Stories
+
+- 利用者として、予約リンクをタップした際に安全に図書館の予約ページが開かれることを期待する
+- 利用者として、不正なURLによりアプリがクラッシュしないことを期待する

--- a/docs/50-validate-reserve-url-scheme/tasks.md
+++ b/docs/50-validate-reserve-url-scheme/tasks.md
@@ -1,0 +1,6 @@
+# Issue #50: Tasks - reserveUrlのURLスキーム検証
+
+- [x] `LibraryAvailabilityCard` にURLスキーム検証ロジックを追加する
+- [x] `LaunchMode.externalApplication` を明示する
+- [x] 不正URL時のエラーハンドリング（予約リンク自体を非表示にする）を追加する
+- [x] ウィジェットテストを追加する（javascript/file/data スキーム拒否、http/https 許可）

--- a/lib/presentation/widgets/library_availability_card.dart
+++ b/lib/presentation/widgets/library_availability_card.dart
@@ -17,6 +17,7 @@ class LibraryAvailabilityCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final reserveUri = _safeReserveUri;
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 8),
       child: Padding(
@@ -45,11 +46,11 @@ class LibraryAvailabilityCard extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             AvailabilityStatusBadge(status: status.statusForLibKey(library.libKey)),
-            if ((status.reserveUrl?.isNotEmpty ?? false) && status.statusForLibKey(library.libKey).isReservable) ...[
+            if (reserveUri != null && status.statusForLibKey(library.libKey).isReservable) ...[
               const SizedBox(height: 8),
               TextButton(
                 onPressed: () {
-                  launchUrl(Uri.parse(status.reserveUrl!));
+                  launchUrl(reserveUri, mode: LaunchMode.externalApplication);
                 },
                 child: const Text('予約する'),
               ),
@@ -58,5 +59,16 @@ class LibraryAvailabilityCard extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  /// Parses [status.reserveUrl] and returns a [Uri] only if the scheme is
+  /// http or https. Returns null for empty, null, or unsafe URLs.
+  Uri? get _safeReserveUri {
+    final raw = status.reserveUrl;
+    if (raw == null || raw.isEmpty) return null;
+    final uri = Uri.tryParse(raw);
+    if (uri == null) return null;
+    if (uri.scheme != 'http' && uri.scheme != 'https') return null;
+    return uri;
   }
 }

--- a/test/presentation/widgets/library_availability_card_test.dart
+++ b/test/presentation/widgets/library_availability_card_test.dart
@@ -185,5 +185,57 @@ void main() {
 
       expect(find.text('予約する'), findsOneWidget);
     });
+
+    testWidgets('does not display reserve URL link when URL has javascript scheme', (tester) async {
+      await tester.pumpWidget(buildSubject(
+        status: const LibraryStatus(
+          systemId: 'Tokyo_Minato',
+          status: AvailabilityStatus.available,
+          reserveUrl: 'javascript:alert(1)',
+          libKeyStatuses: {'みなと': '貸出可'},
+        ),
+      ));
+
+      expect(find.text('予約する'), findsNothing);
+    });
+
+    testWidgets('does not display reserve URL link when URL has file scheme', (tester) async {
+      await tester.pumpWidget(buildSubject(
+        status: const LibraryStatus(
+          systemId: 'Tokyo_Minato',
+          status: AvailabilityStatus.available,
+          reserveUrl: 'file:///etc/passwd',
+          libKeyStatuses: {'みなと': '貸出可'},
+        ),
+      ));
+
+      expect(find.text('予約する'), findsNothing);
+    });
+
+    testWidgets('does not display reserve URL link when URL has data scheme', (tester) async {
+      await tester.pumpWidget(buildSubject(
+        status: const LibraryStatus(
+          systemId: 'Tokyo_Minato',
+          status: AvailabilityStatus.available,
+          reserveUrl: 'data:text/html,<script>alert(1)</script>',
+          libKeyStatuses: {'みなと': '貸出可'},
+        ),
+      ));
+
+      expect(find.text('予約する'), findsNothing);
+    });
+
+    testWidgets('displays reserve URL link when URL has http scheme', (tester) async {
+      await tester.pumpWidget(buildSubject(
+        status: const LibraryStatus(
+          systemId: 'Tokyo_Minato',
+          status: AvailabilityStatus.available,
+          reserveUrl: 'http://example.com/reserve',
+          libKeyStatuses: {'みなと': '貸出可'},
+        ),
+      ));
+
+      expect(find.text('予約する'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Summary

- `LibraryAvailabilityCard` の予約リンクに URL スキーム検証を追加
- `http` / `https` スキームのみ許可し、`javascript:`, `file:`, `data:` 等の不正スキームではリンク自体を非表示にする
- `LaunchMode.externalApplication` を明示してアプリ内 WebView 実行を防止

Closes #50

## Test plan

- [x] `https://` URL で「予約する」が表示されること
- [x] `http://` URL で「予約する」が表示されること
- [x] `javascript:` URL で「予約する」が非表示になること
- [x] `file:` URL で「予約する」が非表示になること
- [x] `data:` URL で「予約する」が非表示になること
- [x] 既存テスト全件パス（リグレッションなし）
- [ ] Android エミュレータで予約リンクタップが正常に外部ブラウザで開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)