### PR TITLE
Add widget tests for BarcodeScannerPage and IsbnInputPage

### DIFF
--- a/docs/51-add-page-widget-tests/design.md
+++ b/docs/51-add-page-widget-tests/design.md
@@ -1,0 +1,62 @@
+# Issue #51: Design - ウィジェットテスト追加
+
+## Architecture Overview
+
+既存のテストファイルにテストケースを追加し、新規のウィジェットテストファイルを作成する。カメラ依存の処理は子ウィジェットの単体テストでカバーする。
+
+## Component Design
+
+### テスト対象と戦略
+
+```mermaid
+graph TD
+    A[BarcodeScannerPage] --> B[CameraErrorWidget]
+    A --> C[CameraPermissionErrorWidget]
+    A --> D[ScanOverlayWidget]
+    A --> E[MobileScannerController]
+
+    B -->|単体テスト新規作成| F[camera_error_widget_test.dart]
+    C -->|単体テスト新規作成| G[camera_permission_error_widget_test.dart]
+    A -->|既存テスト拡充| H[barcode_scanner_page_test.dart]
+
+    I[IsbnInputPage] -->|既存テスト拡充| J[isbn_input_page_test.dart]
+
+    style E fill:#f99,stroke:#333
+    style F fill:#9f9,stroke:#333
+    style G fill:#9f9,stroke:#333
+```
+
+### 新規テストファイル
+
+#### `test/presentation/widgets/camera_error_widget_test.dart`
+
+- エラーメッセージ「カメラの起動に失敗しました」が表示されること
+- 説明文が表示されること
+- 「再試行」ボタンのコールバックが呼ばれること
+- 「ISBNを手動入力する」ボタンのコールバックが呼ばれること
+
+#### `test/presentation/widgets/camera_permission_error_widget_test.dart`
+
+- 権限エラーメッセージ「カメラへのアクセスが許可されていません」が表示されること
+- 説明文が表示されること
+- 「設定を開く」ボタンのコールバックが呼ばれること
+- 「ISBNを手動入力する」ボタンのコールバックが呼ばれること
+
+### 既存テスト拡充
+
+#### `barcode_scanner_page_test.dart`
+
+- 「ISBNを手動入力する」ボタンタップで `/isbn-input` へ遷移すること
+
+#### `isbn_input_page_test.dart`
+
+- 桁数不正（11桁や12桁）のエラーメッセージ表示
+- ISBN-10 で X チェックディジットが有効であること
+
+## Data Flow
+
+変更なし（テストコードのみ）。
+
+## Domain Models
+
+変更なし。

--- a/docs/51-add-page-widget-tests/requirements.md
+++ b/docs/51-add-page-widget-tests/requirements.md
@@ -1,0 +1,37 @@
+# Issue #51: BarcodeScannerPageとIsbnInputPageのウィジェットテスト追加
+
+## Problem Statement
+
+`BarcodeScannerPage` のウィジェットテストは4件のみ（UI表示確認のみ）で、カメラエラーハンドリングやナビゲーションのテストが不足している。また、`CameraErrorWidget` と `CameraPermissionErrorWidget` のテストが存在しない。`IsbnInputPage` のテストは充実しているが、一部エッジケースが未カバー。
+
+## Requirements
+
+### Functional Requirements
+
+- `CameraErrorWidget` のウィジェットテストを追加する（表示確認、コールバック動作）
+- `CameraPermissionErrorWidget` のウィジェットテストを追加する（表示確認、コールバック動作）
+- `BarcodeScannerPage` の「ISBNを手動入力する」ボタンのナビゲーションテストを追加する
+- `IsbnInputPage` のエッジケーステスト（ISBN桁数エラー等）を追加する
+
+### Non-Functional Requirements
+
+- 既存のテストに影響を与えない
+- `MobileScannerController` のモック化が困難なため、カメラ依存のテストは子ウィジェット単体テストでカバーする
+
+## Constraints
+
+- `MobileScannerController` はテスト環境でカメラにアクセスできないため、直接的なバーコード検出テストは対象外
+- カメラエラー状態のテストは `CameraErrorWidget` / `CameraPermissionErrorWidget` の単体テストでカバーする
+
+## Acceptance Criteria
+
+1. `CameraErrorWidget` のテストが追加されていること（エラーメッセージ表示、再試行ボタン、手動入力ボタン）
+2. `CameraPermissionErrorWidget` のテストが追加されていること（権限エラーメッセージ表示、設定ボタン、手動入力ボタン）
+3. `BarcodeScannerPage` の手動入力ナビゲーションテストが追加されていること
+4. `IsbnInputPage` のエッジケーステストが追加されていること
+5. 全テストがパスすること
+
+## User Stories
+
+- 開発者として、カメラエラー時のUIが正しく動作することをテストで保証したい
+- 開発者として、リグレッションを防ぐための十分なテストカバレッジを確保したい

--- a/docs/51-add-page-widget-tests/tasks.md
+++ b/docs/51-add-page-widget-tests/tasks.md
@@ -1,0 +1,6 @@
+# Issue #51: Tasks - ウィジェットテスト追加
+
+- [x] `CameraErrorWidget` のウィジェットテストを作成する（既存テスト6件あり。追加不要）
+- [x] `CameraPermissionErrorWidget` のウィジェットテストを作成する（既存テスト6件あり。追加不要）
+- [x] `BarcodeScannerPage` のナビゲーションテストを追加する（2件追加: キーボードアイコン表示、/isbn-input遷移）
+- [x] `IsbnInputPage` のエッジケーステストを追加する（5件追加: 11桁エラー、12桁エラー、X check digit、978外エラー、ISBN-10エラー）

--- a/test/presentation/pages/barcode_scanner_page_test.dart
+++ b/test/presentation/pages/barcode_scanner_page_test.dart
@@ -23,6 +23,12 @@ void main() {
               body: Text('Result: ${state.pathParameters['isbn']}'),
             ),
           ),
+          GoRoute(
+            path: '/isbn-input',
+            builder: (context, state) => Scaffold(
+              appBar: AppBar(title: const Text('ISBN入力')),
+            ),
+          ),
         ],
       );
     });
@@ -61,6 +67,23 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('ISBNを手動入力する'), findsOneWidget);
+    });
+
+    testWidgets('「ISBNを手動入力する」ボタンにキーボードアイコンが表示される', (tester) async {
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.keyboard), findsOneWidget);
+    });
+
+    testWidgets('「ISBNを手動入力する」ボタンタップで/isbn-inputへ遷移する', (tester) async {
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('ISBNを手動入力する'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('ISBN入力'), findsOneWidget);
     });
   });
 }

--- a/test/presentation/pages/isbn_input_page_test.dart
+++ b/test/presentation/pages/isbn_input_page_test.dart
@@ -215,5 +215,58 @@ void main() {
 
       expect(find.text('ISBN: 9784873117584'), findsOneWidget);
     });
+
+    testWidgets('11桁入力時に桁数エラーメッセージが表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '97848731175');
+      await tester.pump();
+
+      expect(find.text('ISBNは10桁または13桁で入力してください'), findsOneWidget);
+    });
+
+    testWidgets('12桁入力時に桁数エラーメッセージが表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '978487311758');
+      await tester.pump();
+
+      expect(find.text('ISBNは10桁または13桁で入力してください'), findsOneWidget);
+    });
+
+    testWidgets('ISBN-10のXチェックディジットが有効として認識される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      // 080442957X: check digit X (=10), valid ISBN-10
+      await tester.enterText(find.byType(TextField), '080442957X');
+      await tester.pump();
+
+      expect(find.text('有効なISBNです'), findsOneWidget);
+      final button = tester.widget<FilledButton>(find.widgetWithText(FilledButton, '検索する'));
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('978以外で始まるISBN-13はエラーメッセージが表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '1234567890123');
+      await tester.pump();
+
+      expect(find.text('ISBN-13 は 978 または 979 で始まる必要があります'), findsOneWidget);
+    });
+
+    testWidgets('無効なISBN-10入力時にエラーメッセージが表示される', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '4873117586');
+      await tester.pump();
+
+      expect(find.text('ISBN-10 のチェックディジットが正しくありません'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Summary

- BarcodeScannerPage に「ISBNを手動入力する」ボタンのナビゲーションテストとアイコン表示テストを追加（2件）
- IsbnInputPage にエッジケーステストを追加（5件）: 桁数不正エラー、ISBN-10 Xチェックディジット、978外プレフィックスエラー、ISBN-10チェックディジットエラー

Closes #51

## Test plan

- [x] BarcodeScannerPage: キーボードアイコン表示テスト
- [x] BarcodeScannerPage: /isbn-input ナビゲーションテスト
- [x] IsbnInputPage: 11桁入力時の桁数エラーメッセージ
- [x] IsbnInputPage: 12桁入力時の桁数エラーメッセージ
- [x] IsbnInputPage: ISBN-10 X チェックディジット認識
- [x] IsbnInputPage: 978以外で始まるISBN-13エラーメッセージ
- [x] IsbnInputPage: 無効なISBN-10エラーメッセージ
- [x] 全352テストパス（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)