### PR TITLE
Replace results[0] hardcode with explicit ISBN lookup

### DIFF
--- a/docs/52-fix-results-hardcode/design.md
+++ b/docs/52-fix-results-hardcode/design.md
@@ -1,0 +1,37 @@
+# Issue #52: Design - results[0]ハードコード修正
+
+## Architecture Overview
+
+`BookSearchResultPage` 内の `results[0]` 参照を、ISBN による明示的な検索に変更する。
+
+## Component Design
+
+### 変更箇所
+
+```mermaid
+graph LR
+    A["results[0]"] -->|変更| B["results.firstWhere((r) => r.isbn == isbn)"]
+```
+
+### 変更対象メソッド
+
+1. `_saveSearchHistory`: 検索履歴保存時の結果参照
+2. `_buildResultState`: 検索結果表示時の結果参照
+
+### ヘルパーメソッド
+
+ISBNによる結果検索ロジックを共通化するため、`_findResultForIsbn` ヘルパーメソッドを追加する。
+
+```dart
+BookAvailability? _findResultForIsbn(List<BookAvailability> results) {
+  return results.where((r) => r.isbn == isbn).firstOrNull;
+}
+```
+
+## Data Flow
+
+変更なし。
+
+## Domain Models
+
+変更なし。

--- a/docs/52-fix-results-hardcode/requirements.md
+++ b/docs/52-fix-results-hardcode/requirements.md
@@ -1,0 +1,31 @@
+# Issue #52: results[0]のハードコード参照を明示的なISBN検索に変更
+
+## Problem Statement
+
+`BookSearchResultPage` で `results[0]` をハードコードで参照しているが、カーリルAPIは複数ISBNの同時検索をサポートしており、将来的に複数結果が返る可能性がある。前提条件が明示されていないため保守時に誤解される恐れがある。
+
+## Requirements
+
+### Functional Requirements
+
+- `results[0]` を `results.firstWhere((r) => r.isbn == isbn)` に変更し、ISBNで明示的に検索する
+- 該当ISBNの結果が見つからない場合のフォールバック処理を追加する
+
+### Non-Functional Requirements
+
+- 既存の動作に変更がないこと
+
+## Constraints
+
+- 現在のアプリは単一ISBNのみ検索するため、`results[0]` でも動作する
+- 将来の複数ISBN検索対応への布石
+
+## Acceptance Criteria
+
+1. `_saveSearchHistory` で `results[0]` の代わりに ISBN で明示検索していること
+2. `_buildResultState` で `results[0]` の代わりに ISBN で明示検索していること
+3. 全テストがパスすること
+
+## User Stories
+
+- 開発者として、コードの意図が明確に表現されていることで保守性を向上させたい

--- a/docs/52-fix-results-hardcode/tasks.md
+++ b/docs/52-fix-results-hardcode/tasks.md
@@ -1,0 +1,6 @@
+# Issue #52: Tasks - results[0]ハードコード修正
+
+- [x] `_findResultForIsbn` ヘルパーメソッドのテストを追加する
+- [x] `_findResultForIsbn` ヘルパーメソッドを実装する
+- [x] `_saveSearchHistory` の `results[0]` を置き換える
+- [x] `_buildResultState` の `results[0]` を置き換える

--- a/lib/presentation/pages/book_search_result_page.dart
+++ b/lib/presentation/pages/book_search_result_page.dart
@@ -59,7 +59,8 @@ class BookSearchResultPage extends ConsumerWidget {
   }
 
   void _saveSearchHistory(WidgetRef ref, List<BookAvailability> results) {
-    final result = results[0];
+    final result = _findResultForIsbn(results);
+    if (result == null) return;
     final statuses = <String, String>{};
     for (final entry in result.libraryStatuses.entries) {
       statuses[entry.key] = entry.value.status.name;
@@ -70,6 +71,10 @@ class BookSearchResultPage extends ConsumerWidget {
       libraryStatuses: statuses,
     );
     ref.read(searchHistoryProvider.notifier).save(historyEntry);
+  }
+
+  BookAvailability? _findResultForIsbn(List<BookAvailability> results) {
+    return results.where((r) => r.isbn == isbn).firstOrNull;
   }
 
   Widget _buildLoadingState(BuildContext context) {
@@ -138,8 +143,9 @@ class BookSearchResultPage extends ConsumerWidget {
           const SizedBox(height: 8),
           if (results.isNotEmpty)
             ...libraries.map((library) {
+              final result = _findResultForIsbn(results);
               final status =
-                  results[0].libraryStatuses[library.systemId];
+                  result?.libraryStatuses[library.systemId];
               if (status == null) return const SizedBox.shrink();
               return LibraryAvailabilityCard(
                 library: library,

--- a/test/presentation/pages/book_search_result_page_test.dart
+++ b/test/presentation/pages/book_search_result_page_test.dart
@@ -430,5 +430,81 @@ void main() {
 
       expect(fakeHistoryRepo.savedEntries, isEmpty);
     });
+
+    testWidgets('displays correct result when multiple BookAvailability results exist', (tester) async {
+      final results = [
+        BookAvailability(
+          isbn: '9784000000000',
+          libraryStatuses: {
+            'Tokyo_Minato': const LibraryStatus(
+              systemId: 'Tokyo_Minato',
+              status: AvailabilityStatus.notFound,
+              libKeyStatuses: {'みなと': '蔵書なし'},
+            ),
+          },
+        ),
+        BookAvailability(
+          isbn: '9784123456789',
+          libraryStatuses: {
+            'Tokyo_Minato': const LibraryStatus(
+              systemId: 'Tokyo_Minato',
+              status: AvailabilityStatus.available,
+              libKeyStatuses: {'みなと': '貸出可'},
+            ),
+          },
+        ),
+      ];
+
+      await tester.pumpWidget(buildSubject(
+        libraryRepo: FakeLibraryRepository(results),
+        registeredRepo: FakeRegisteredLibraryRepository([_library1]),
+        isbn: '9784123456789',
+      ));
+      await tester.pumpAndSettle();
+
+      // Should display the result for the searched ISBN, not results[0]
+      expect(find.text('貸出可能'), findsOneWidget);
+      expect(find.text('蔵書なし'), findsNothing);
+    });
+
+    testWidgets('saves correct search history when multiple results exist', (tester) async {
+      final results = [
+        BookAvailability(
+          isbn: '9784000000000',
+          libraryStatuses: {
+            'Tokyo_Minato': const LibraryStatus(
+              systemId: 'Tokyo_Minato',
+              status: AvailabilityStatus.notFound,
+              libKeyStatuses: {'みなと': '蔵書なし'},
+            ),
+          },
+        ),
+        BookAvailability(
+          isbn: '9784123456789',
+          libraryStatuses: {
+            'Tokyo_Minato': const LibraryStatus(
+              systemId: 'Tokyo_Minato',
+              status: AvailabilityStatus.available,
+              libKeyStatuses: {'みなと': '貸出可'},
+            ),
+          },
+        ),
+      ];
+
+      await tester.pumpWidget(buildSubject(
+        libraryRepo: FakeLibraryRepository(results),
+        registeredRepo: FakeRegisteredLibraryRepository([_library1]),
+        historyRepo: fakeHistoryRepo,
+        isbn: '9784123456789',
+      ));
+      await tester.pumpAndSettle();
+
+      expect(fakeHistoryRepo.savedEntries, hasLength(1));
+      expect(fakeHistoryRepo.savedEntries[0].isbn, '9784123456789');
+      expect(
+        fakeHistoryRepo.savedEntries[0].libraryStatuses['Tokyo_Minato'],
+        'available',
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

- `results[0]` のハードコード参照を `_findResultForIsbn` ヘルパーメソッドによる ISBN 明示検索に置き換え
- 複数 `BookAvailability` 結果が返された場合でも正しい結果を使用するようになった
- 該当 ISBN が見つからない場合の null safety 対応

Closes #52

## Test plan

- [x] 複数結果から正しいISBNの結果を表示するテスト
- [x] 複数結果から正しい検索履歴を保存するテスト
- [x] 既存16テスト全パス
- [x] 全354テストパス（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)