### PR TITLE
ページ遷移の導線改善（戻るボタン・行き止まり・スナックバー）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ swa-cli.config.json
 
 # Claude Code local settings
 .claude/
+.vite/

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { closeSnackbar, enqueueSnackbar } from 'notistack';
 
+import { App } from '@/App';
 import type { Library } from '@/domain/models/library';
 import type { RegisteredLibraryRepository } from '@/domain/repositories/registeredLibraryRepository';
 import { makeFakeDeps, renderRouteWithProviders } from '@/test/testUtils';
@@ -41,6 +43,40 @@ describe('LibCheckApp', () => {
 
     await waitFor(() => {
       expect(screen.getByText('登録図書館')).toBeInTheDocument();
+    });
+  });
+
+  it('スナックバーはボトムナビゲーションと重ならないよう上部（top-center）に表示される', async () => {
+    // App.tsx の SnackbarProvider 設定そのものを検証したいので、
+    // testUtils のプロバイダーではなく実際の <App /> をレンダリングする。
+    window.history.replaceState(null, '', '/');
+    render(<App />);
+
+    // ルーターと登録図書館クエリの初期化（空 → /library リダイレクト）を待つ。
+    await waitFor(() => {
+      expect(screen.getByText('登録図書館')).toBeInTheDocument();
+    });
+
+    // notistack v3 のモジュールレベル API でスナックバーを表示する。
+    act(() => {
+      enqueueSnackbar('テスト通知');
+    });
+    const message = await screen.findByText('テスト通知');
+
+    const container = message.closest('.notistack-SnackbarContainer');
+    expect(container).not.toBeNull();
+
+    // notistack はクラス名がハッシュ化されているため、計算済みスタイルで
+    // anchorOrigin を検証する（top 配置なら top が、bottom 配置なら bottom が
+    // px 値で設定される）。
+    const style = window.getComputedStyle(container as HTMLElement);
+    expect(style.top).toMatch(/^\d+px$/);
+    expect(style.bottom).toBe('');
+    // horizontal: 'center' は left: 50% (+ translateX(-50%)) で表現される。
+    expect(style.left).toBe('50%');
+
+    act(() => {
+      closeSnackbar();
     });
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { CssBaseline, ThemeProvider } from '@mui/material';
+import { CssBaseline, GlobalStyles, ThemeProvider } from '@mui/material';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from 'react-router-dom';
 import { SnackbarProvider } from 'notistack';
@@ -35,7 +35,18 @@ export function App() {
       <QueryClientProvider client={queryClient}>
         <ThemeProvider theme={theme}>
           <CssBaseline />
-          <SnackbarProvider>
+          {/* モバイル幅では画面下部固定の BottomNavigation とスナックバーが
+              重なってタブのタップをブロックするため、上部に表示する。
+              さらに AppBar(56px) のタイトル・戻る・フラッシュの各ボタンを
+              覆わないよう、表示位置を AppBar の直下までオフセットする。 */}
+          <GlobalStyles
+            styles={{
+              '.notistack-SnackbarContainer': { top: '64px !important' },
+            }}
+          />
+          <SnackbarProvider
+            anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+          >
             <SelectedLibrariesProvider>
               <RouterProvider router={router} />
             </SelectedLibrariesProvider>

--- a/src/presentation/hooks/useBackNavigation.ts
+++ b/src/presentation/hooks/useBackNavigation.ts
@@ -1,0 +1,23 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * 戻るナビゲーション用フック。
+ *
+ * 遷移履歴があれば前の画面へ戻り、URL直アクセスやリロード直後など
+ * 履歴が無い場合はホームへフォールバックする。
+ * 履歴の有無は react-router の data router が設定する
+ * `window.history.state.idx`（初期エントリは 0）で判定する。
+ */
+export function useBackNavigation(): () => void {
+  const navigate = useNavigate();
+
+  return useCallback(() => {
+    const idx = (window.history.state as { idx?: number } | null)?.idx ?? 0;
+    if (idx > 0) {
+      navigate(-1);
+    } else {
+      navigate('/', { replace: true });
+    }
+  }, [navigate]);
+}

--- a/src/presentation/pages/BarcodeScannerPage.tsx
+++ b/src/presentation/pages/BarcodeScannerPage.tsx
@@ -4,12 +4,9 @@ import { enqueueSnackbar } from 'notistack';
 import { BrowserMultiFormatReader } from '@zxing/browser';
 import type { IScannerControls } from '@zxing/browser';
 import { BarcodeFormat, DecodeHintType } from '@zxing/library';
-import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
-import Toolbar from '@mui/material/Toolbar';
-import Typography from '@mui/material/Typography';
 import FlashOnIcon from '@mui/icons-material/FlashOn';
 import FlashOffIcon from '@mui/icons-material/FlashOff';
 import KeyboardIcon from '@mui/icons-material/Keyboard';
@@ -18,6 +15,7 @@ import { interpretScannedBarcode } from '@/presentation/utils/scanInterpreter';
 import { CameraErrorWidget } from '@/presentation/widgets/CameraErrorWidget';
 import { CameraPermissionErrorWidget } from '@/presentation/widgets/CameraPermissionErrorWidget';
 import { ScanOverlayWidget } from '@/presentation/widgets/ScanOverlayWidget';
+import { SubPageAppBar } from '@/presentation/widgets/SubPageAppBar';
 
 type CameraErrorType = 'permission' | 'error';
 
@@ -161,13 +159,7 @@ export function BarcodeScannerPage(): JSX.Element {
   if (errorType === 'permission') {
     return (
       <Box sx={{ minHeight: '100vh' }}>
-        <AppBar position="static">
-          <Toolbar>
-            <Typography variant="h6" component="div">
-              バーコードスキャン
-            </Typography>
-          </Toolbar>
-        </AppBar>
+        <SubPageAppBar title="バーコードスキャン" />
         <CameraPermissionErrorWidget
           onRetry={retryCamera}
           onManualInput={goManualInput}
@@ -179,13 +171,7 @@ export function BarcodeScannerPage(): JSX.Element {
   if (errorType === 'error') {
     return (
       <Box sx={{ minHeight: '100vh' }}>
-        <AppBar position="static">
-          <Toolbar>
-            <Typography variant="h6" component="div">
-              バーコードスキャン
-            </Typography>
-          </Toolbar>
-        </AppBar>
+        <SubPageAppBar title="バーコードスキャン" />
         <CameraErrorWidget
           onRetry={retryCamera}
           onManualInput={goManualInput}
@@ -198,11 +184,9 @@ export function BarcodeScannerPage(): JSX.Element {
     <Box
       sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}
     >
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-            バーコードスキャン
-          </Typography>
+      <SubPageAppBar
+        title="バーコードスキャン"
+        trailing={
           <IconButton
             color="inherit"
             aria-label="flash"
@@ -212,8 +196,8 @@ export function BarcodeScannerPage(): JSX.Element {
           >
             {isFlashOn ? <FlashOnIcon /> : <FlashOffIcon />}
           </IconButton>
-        </Toolbar>
-      </AppBar>
+        }
+      />
       <Box sx={{ position: 'relative', flex: 1, backgroundColor: '#000' }}>
         <video
           ref={videoRef}

--- a/src/presentation/pages/BookSearchResultPage.test.tsx
+++ b/src/presentation/pages/BookSearchResultPage.test.tsx
@@ -208,6 +208,59 @@ describe('BookSearchResultPage', () => {
     expect(screen.getByTestId('CameraAltIcon')).toBeInTheDocument();
   });
 
+  test('source=scan のとき「別の本をスキャンする」でスキャン画面へ遷移する', async () => {
+    const results: BookAvailability[] = [
+      {
+        isbn: '9784123456789',
+        libraryStatuses: {
+          Tokyo_Minato: {
+            systemId: 'Tokyo_Minato',
+            status: AvailabilityStatus.available,
+            libKeyStatuses: { みなと: '貸出可' },
+          },
+        },
+      },
+    ];
+
+    const { user } = renderSubject({
+      libraryRepo: new FakeLibraryRepository(results),
+      registeredRepo: new FakeRegisteredLibraryRepository([library1]),
+      source: 'scan',
+    });
+
+    await user.click(await screen.findByText('別の本をスキャンする'));
+
+    // jsdom にはカメラが無いためスキャン画面はエラーフォールバックを表示するが、
+    // AppBar タイトル「バーコードスキャン」で遷移先を判定できる。
+    expect(await screen.findByText('バーコードスキャン')).toBeInTheDocument();
+  });
+
+  test('直アクセス（履歴なし・source なし）でも「別の本を検索する」でISBN入力画面へ遷移する', async () => {
+    // renderRouteWithProviders は /result/:isbn を初期ルートにするため、
+    // 遷移履歴の無いURL直アクセスを再現できる（navigate(-1) では行き止まりになるケース）。
+    const results: BookAvailability[] = [
+      {
+        isbn: '9784123456789',
+        libraryStatuses: {
+          Tokyo_Minato: {
+            systemId: 'Tokyo_Minato',
+            status: AvailabilityStatus.available,
+            libKeyStatuses: { みなと: '貸出可' },
+          },
+        },
+      },
+    ];
+
+    const { user } = renderSubject({
+      libraryRepo: new FakeLibraryRepository(results),
+      registeredRepo: new FakeRegisteredLibraryRepository([library1]),
+    });
+
+    await user.click(await screen.findByText('別の本を検索する'));
+
+    expect(await screen.findByText('ISBN入力')).toBeInTheDocument();
+  });
+
   test('saves search history when results are loaded', async () => {
     const results: BookAvailability[] = [
       {

--- a/src/presentation/pages/BookSearchResultPage.tsx
+++ b/src/presentation/pages/BookSearchResultPage.tsx
@@ -5,12 +5,10 @@ import {
   useSearchParams,
 } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
-import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CircularProgress from '@mui/material/CircularProgress';
-import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
 import BookIcon from '@mui/icons-material/Book';
@@ -29,6 +27,7 @@ import { useBookAvailability } from '@/presentation/hooks/useBookAvailability';
 import { useRegisteredLibraries } from '@/presentation/hooks/useRegisteredLibraries';
 import { useSearchHistoryMutations } from '@/presentation/hooks/useSearchHistory';
 import { LibraryAvailabilityCard } from '@/presentation/widgets/LibraryAvailabilityCard';
+import { SubPageAppBar } from '@/presentation/widgets/SubPageAppBar';
 
 /**
  * 蔵書検索結果画面。
@@ -116,7 +115,9 @@ export function BookSearchResultPage(): JSX.Element {
       <Button
         variant="outlined"
         startIcon={isScan ? <CameraAltIcon /> : <SearchIcon />}
-        onClick={() => navigate(-1)}
+        // 履歴に依存する navigate(-1) は直アクセス時に行き止まりになるため、
+        // ラベルと一致する明示的な遷移先に移動する。
+        onClick={() => navigate(isScan ? '/scan' : '/isbn-input')}
         sx={{ width: '100%' }}
       >
         {isScan ? '別の本をスキャンする' : '別の本を検索する'}
@@ -259,13 +260,7 @@ export function BookSearchResultPage(): JSX.Element {
 
   return (
     <Box sx={{ minHeight: '100vh' }}>
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6" component="div">
-            検索結果
-          </Typography>
-        </Toolbar>
-      </AppBar>
+      <SubPageAppBar title="検索結果" />
       {renderBody()}
     </Box>
   );

--- a/src/presentation/pages/CitySelectionPage.test.tsx
+++ b/src/presentation/pages/CitySelectionPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { screen } from '@testing-library/react';
 
 import { makeFakeDeps, renderRouteWithProviders } from '@/test/testUtils';
@@ -59,6 +59,11 @@ function depsWith(repository: LibraryRepository): AppDependencies {
 }
 
 describe('CitySelectionPage', () => {
+  afterEach(() => {
+    // テストで模擬した履歴インデックスをリセットする。
+    window.history.replaceState(null, '');
+  });
+
   it('renders AppBar with prefecture name', async () => {
     renderRouteWithProviders('/library/add/東京都', {
       deps: depsWith(mockLibraryRepository([])),
@@ -101,6 +106,22 @@ describe('CitySelectionPage', () => {
     expect(screen.getByText('港区')).toBeInTheDocument();
     expect(screen.queryByText('新宿区')).not.toBeInTheDocument();
     expect(screen.queryByText('千代田区')).not.toBeInTheDocument();
+  });
+
+  it('戻るボタンで都道府県選択画面へ戻る', async () => {
+    const { user } = renderRouteWithProviders('/library/add', {
+      deps: depsWith(mockLibraryRepository([])),
+    });
+
+    await user.click(await screen.findByText('東京都'));
+    expect(await screen.findByText('東京都の市区町村')).toBeInTheDocument();
+
+    // createMemoryRouter は window.history を更新しないため、
+    // 遷移済みの履歴インデックスを模擬する。
+    window.history.replaceState({ idx: 1 }, '');
+    await user.click(screen.getByRole('button', { name: '戻る' }));
+
+    expect(await screen.findByText('都道府県を選択')).toBeInTheDocument();
   });
 
   it('shows ErrorStateWidget on failure', async () => {

--- a/src/presentation/pages/CitySelectionPage.tsx
+++ b/src/presentation/pages/CitySelectionPage.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
-  AppBar,
   Box,
   CircularProgress,
   InputAdornment,
@@ -9,13 +8,13 @@ import {
   ListItemButton,
   ListItemText,
   TextField,
-  Toolbar,
   Typography,
 } from '@mui/material';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import SearchIcon from '@mui/icons-material/Search';
 import { useCityList } from '@/presentation/hooks/useCityList';
 import { ErrorStateWidget } from '@/presentation/widgets/ErrorStateWidget';
+import { SubPageAppBar } from '@/presentation/widgets/SubPageAppBar';
 
 /**
  * 市区町村選択ページ。
@@ -103,11 +102,7 @@ export function CitySelectionPage() {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6">{`${pref}の市区町村`}</Typography>
-        </Toolbar>
-      </AppBar>
+      <SubPageAppBar title={`${pref}の市区町村`} />
       <Box sx={{ flexGrow: 1, overflow: 'auto' }}>{renderBody()}</Box>
     </Box>
   );

--- a/src/presentation/pages/IsbnInputPage.test.tsx
+++ b/src/presentation/pages/IsbnInputPage.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { screen } from '@testing-library/react';
 
-import { renderRouteWithProviders } from '@/test/testUtils';
+import { makeFakeDeps, renderRouteWithProviders } from '@/test/testUtils';
+import type { Library } from '@/domain/models/library';
 
 /**
  * Port of `test/presentation/pages/isbn_input_page_test.dart`.
@@ -10,7 +11,27 @@ import { renderRouteWithProviders } from '@/test/testUtils';
  * `/result/:isbn` (the `BookSearchResultPage` renders both the "検索結果" AppBar
  * title and an `ISBN: <isbn>` line, mirroring the Flutter stub route).
  */
+// ホーム画面を表示するために登録しておく図書館
+// （登録0件だとホームは /library へリダイレクトされる）。
+const sampleLibrary: Library = {
+  systemId: 'system1',
+  systemName: 'テスト図書館システム',
+  libKey: 'key1',
+  libId: 'id1',
+  shortName: 'テスト図書館',
+  formalName: 'テスト図書館',
+  address: '東京都港区',
+  pref: '東京都',
+  city: '港区',
+  category: 'MEDIUM',
+};
+
 describe('IsbnInputPage', () => {
+  afterEach(() => {
+    // テストで模擬した履歴インデックスをリセットする。
+    window.history.replaceState(null, '');
+  });
+
   it('AppBarに「ISBN入力」と表示される', async () => {
     renderRouteWithProviders('/isbn-input');
 
@@ -73,6 +94,32 @@ describe('IsbnInputPage', () => {
     await user.click(await screen.findByText('バーコードスキャンへ'));
 
     expect(await screen.findByText('バーコードスキャン')).toBeInTheDocument();
+  });
+
+  it('ホームから遷移後、戻るボタンでホームへ戻る', async () => {
+    const deps = makeFakeDeps();
+    await deps.registeredLibraryRepository.add(sampleLibrary);
+    const { user } = renderRouteWithProviders('/', { deps });
+
+    await user.click(await screen.findByText('ISBNを入力'));
+    expect(await screen.findByText('ISBN入力')).toBeInTheDocument();
+
+    // createMemoryRouter は window.history を更新しないため、
+    // 遷移済みの履歴インデックスを模擬する。
+    window.history.replaceState({ idx: 1 }, '');
+    await user.click(screen.getByRole('button', { name: '戻る' }));
+
+    expect(await screen.findByText('LibCheck')).toBeInTheDocument();
+  });
+
+  it('履歴が無いとき戻るボタンでホームへ遷移する', async () => {
+    const deps = makeFakeDeps();
+    await deps.registeredLibraryRepository.add(sampleLibrary);
+    const { user } = renderRouteWithProviders('/isbn-input', { deps });
+
+    await user.click(await screen.findByRole('button', { name: '戻る' }));
+
+    expect(await screen.findByText('LibCheck')).toBeInTheDocument();
   });
 
   it('数値キーボードに固定せずX・ハイフンを入力できる', () => {

--- a/src/presentation/pages/IsbnInputPage.tsx
+++ b/src/presentation/pages/IsbnInputPage.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  AppBar,
-  Toolbar,
   Typography,
   Box,
   TextField,
@@ -10,6 +8,7 @@ import {
   useTheme,
 } from '@mui/material';
 import { isbnValidator } from '@/domain/utils/isbnValidator';
+import { SubPageAppBar } from '@/presentation/widgets/SubPageAppBar';
 
 /**
  * ISBN手動入力画面。
@@ -37,13 +36,7 @@ export function IsbnInputPage(): React.ReactElement {
 
   return (
     <Box>
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6" component="div">
-            ISBN入力
-          </Typography>
-        </Toolbar>
-      </AppBar>
+      <SubPageAppBar title="ISBN入力" />
       <Box sx={{ p: 2 }}>
         <Typography variant="h6">ISBNを入力してください</Typography>
         <Box sx={{ height: 16 }} />

--- a/src/presentation/pages/LibraryListPage.tsx
+++ b/src/presentation/pages/LibraryListPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { enqueueSnackbar } from 'notistack';
-import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
@@ -10,7 +9,6 @@ import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 
 import { libraryKey } from '@/domain/models/library';
@@ -18,6 +16,7 @@ import { useLibraryList } from '@/presentation/hooks/useLibraryList';
 import { useRegisteredLibraryMutations } from '@/presentation/hooks/useRegisteredLibraries';
 import { useSelectedLibraries } from '@/presentation/hooks/useSelectedLibraries';
 import { ErrorStateWidget } from '@/presentation/widgets/ErrorStateWidget';
+import { SubPageAppBar } from '@/presentation/widgets/SubPageAppBar';
 
 /**
  * 図書館一覧画面。
@@ -133,13 +132,7 @@ export function LibraryListPage(): JSX.Element {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6" component="div">
-            {`${city}の図書館`}
-          </Typography>
-        </Toolbar>
-      </AppBar>
+      <SubPageAppBar title={`${city}の図書館`} />
       {renderBody()}
     </Box>
   );

--- a/src/presentation/pages/PrefectureSelectionPage.tsx
+++ b/src/presentation/pages/PrefectureSelectionPage.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  AppBar,
-  Toolbar,
   Typography,
   Box,
   TextField,
@@ -17,6 +15,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import type { RegionGroup } from '@/domain/data/japanesePrefectures';
 import { JAPANESE_PREFECTURE_REGIONS } from '@/domain/data/japanesePrefectures';
+import { SubPageAppBar } from '@/presentation/widgets/SubPageAppBar';
 
 /**
  * 都道府県選択画面。
@@ -31,13 +30,7 @@ export function PrefectureSelectionPage(): React.ReactElement {
 
   return (
     <Box>
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6" component="div">
-            都道府県を選択
-          </Typography>
-        </Toolbar>
-      </AppBar>
+      <SubPageAppBar title="都道府県を選択" />
       <Box sx={{ p: 2 }}>
         <TextField
           fullWidth

--- a/src/presentation/widgets/SubPageAppBar.test.tsx
+++ b/src/presentation/widgets/SubPageAppBar.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { Routes, Route, useLocation, useNavigate } from 'react-router-dom';
+
+import { renderWithProviders } from '@/test/testUtils';
+import { SubPageAppBar } from '@/presentation/widgets/SubPageAppBar';
+
+/** 現在のパスを表示するテスト用コンポーネント。 */
+function LocationDisplay(): JSX.Element {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+/** ボタンクリックで遷移して履歴を1件積むテスト用コンポーネント。 */
+function PrevPage({ to }: { to: string }): JSX.Element {
+  const navigate = useNavigate();
+  return (
+    <div>
+      <p>前の画面</p>
+      <button type="button" onClick={() => navigate(to)}>
+        進む
+      </button>
+    </div>
+  );
+}
+
+describe('SubPageAppBar', () => {
+  afterEach(() => {
+    // テストで模擬した履歴インデックスをリセットする。
+    window.history.replaceState(null, '');
+  });
+
+  it('タイトルと戻るボタンが表示される', () => {
+    renderWithProviders(<SubPageAppBar title="テストタイトル" />);
+
+    expect(screen.getByText('テストタイトル')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '戻る' })).toBeInTheDocument();
+  });
+
+  it('trailing が AppBar 内に表示される', () => {
+    renderWithProviders(
+      <SubPageAppBar
+        title="テストタイトル"
+        trailing={<button type="button">フラッシュ</button>}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'フラッシュ' }),
+    ).toBeInTheDocument();
+  });
+
+  it('履歴があるとき戻るボタンで前の画面へ戻る', async () => {
+    const { user } = renderWithProviders(
+      <Routes>
+        <Route path="/prev" element={<PrevPage to="/current" />} />
+        <Route
+          path="/current"
+          element={<SubPageAppBar title="現在の画面" />}
+        />
+      </Routes>,
+      { route: '/prev' },
+    );
+
+    await user.click(screen.getByRole('button', { name: '進む' }));
+    expect(await screen.findByText('現在の画面')).toBeInTheDocument();
+
+    // MemoryRouter は window.history を更新しないため、遷移済みの
+    // 履歴インデックスを模擬する。
+    window.history.replaceState({ idx: 1 }, '');
+    await user.click(screen.getByRole('button', { name: '戻る' }));
+
+    expect(await screen.findByText('前の画面')).toBeInTheDocument();
+  });
+
+  it('履歴が無いとき戻るボタンでホームへ遷移する', async () => {
+    const { user } = renderWithProviders(
+      <Routes>
+        <Route path="/" element={<LocationDisplay />} />
+        <Route
+          path="/sub"
+          element={
+            <>
+              <SubPageAppBar title="サブページ" />
+              <LocationDisplay />
+            </>
+          }
+        />
+      </Routes>,
+      { route: '/sub' },
+    );
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/sub');
+
+    await user.click(screen.getByRole('button', { name: '戻る' }));
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/');
+  });
+});

--- a/src/presentation/widgets/SubPageAppBar.tsx
+++ b/src/presentation/widgets/SubPageAppBar.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react';
+import AppBar from '@mui/material/AppBar';
+import IconButton from '@mui/material/IconButton';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+
+import { useBackNavigation } from '@/presentation/hooks/useBackNavigation';
+
+export interface SubPageAppBarProps {
+  title: string;
+  /** AppBar 右端に表示する要素（フラッシュボタン等）。 */
+  trailing?: ReactNode;
+}
+
+/**
+ * サブページ共通の AppBar。
+ *
+ * Flutter の AppBar が自動表示していた戻るボタンを再現する。
+ * 履歴が無い場合はホームへフォールバックする（useBackNavigation 参照）。
+ */
+export function SubPageAppBar({
+  title,
+  trailing,
+}: SubPageAppBarProps): JSX.Element {
+  const goBack = useBackNavigation();
+
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <IconButton
+          edge="start"
+          color="inherit"
+          aria-label="戻る"
+          onClick={goBack}
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+          {title}
+        </Typography>
+        {trailing}
+      </Toolbar>
+    </AppBar>
+  );
+}


### PR DESCRIPTION
## 概要

公開前の導線チェック（Playwright による全17ステップのウォークスルー + 全画面の導線監査）で見つかった要改善3点を修正します。

## 修正内容

### 1. 全サブページに「戻る」ボタンを追加
タブ3画面以外（図書館登録3画面・ISBN入力・スキャン・検索結果）には戻る導線が一切なく、アプリ内UIだけでは前の画面に戻れませんでした（Flutter の AppBar が自動表示していた戻る矢印が移植で喪失）。
- 共通ウィジェット `SubPageAppBar`（戻るボタン付き AppBar）を導入し全サブページに適用
- `useBackNavigation` フック: 遷移履歴があれば `navigate(-1)`、URL直アクセス等で履歴が無ければホームへフォールバック

### 2. 検索結果画面の行き止まり解消 + ラベル不一致修正
`/result/:isbn` への直アクセス（リロード・共有リンク）時、唯一のボタン「別の本を検索する」が `navigate(-1)` のため無反応でした。ラベルと一致する明示的な遷移先（`/isbn-input`・`/scan`）に変更。履歴から開いた場合に「検索する」と言いつつ履歴一覧へ戻るラベル不一致も同時に解消。

### 3. スナックバーがボトムナビを覆いタップをブロックする問題
登録完了スナックバー（bottom-left）がモバイル幅でボトムナビ3タブに完全に重なり、表示中はタブが押せませんでした。top-center に変更し、AppBar のボタン類（戻る・フラッシュ）を覆わないよう AppBar 直下(64px)にオフセット。

## 実装メモ

3つの修正は並行エージェントで TDD 実施（新規テスト9件、テスト 193→203件）。`.vite/`（dev cache）の .gitignore 追加を含む。

## Test Plan

- [x] ユニット/コンポーネントテスト全203件パス・`tsc -b` 通過
- [x] ブラウザ実機検証 11/11 パス（Playwright・モバイルビューポート390px）
  - [x] 登録フロー各画面に戻るボタンが表示され、市区町村→戻るで都道府県選択へ戻る
  - [x] 直アクセスの結果画面で「別の本を検索する」→ ISBN入力へ遷移（行き止まり解消）
  - [x] 直アクセスの結果画面で戻るボタン → ホームへフォールバック
  - [x] スナックバー表示中にボトムナビがタップ可能・AppBar 直下に表示（スクリーンショット確認済み）
  - [x] カメラ不可時のスキャン画面にも戻るボタン表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)