### PR TITLE
インフラを Bicep で IaC 化（#75）

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,79 @@
+name: Infra (Bicep)
+
+# IaC（infra/ 配下の Bicep）専用のワークフロー。アプリ配信
+# （azure-static-web-apps.yml）とは責務を分離する。
+# - PR（infra/ 変更）        : what-if（差分プレビュー・読み取りのみ）
+# - main 反映 / 手動実行     : apply（production 環境の承認ゲートを通す）
+on:
+  pull_request:
+    paths:
+      - 'infra/**'
+      - '.github/workflows/infra.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'infra/**'
+      - '.github/workflows/infra.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: infra-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write # OIDC ログイン用
+  contents: read
+
+env:
+  RESOURCE_GROUP: rg-libcheck
+
+jobs:
+  what-if:
+    name: what-if (PR preview)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: what-if
+        env:
+          CALIL_APP_KEY: ${{ secrets.CALIL_APP_KEY }}
+        run: |
+          az deployment group what-if \
+            --resource-group "$RESOURCE_GROUP" \
+            --template-file infra/main.bicep \
+            --parameters infra/main.bicepparam
+
+  apply:
+    name: apply (production)
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    # 承認ゲート: production 環境の required reviewers を通過してから実行される。
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: what-if (log)
+        env:
+          CALIL_APP_KEY: ${{ secrets.CALIL_APP_KEY }}
+        run: |
+          az deployment group what-if \
+            --resource-group "$RESOURCE_GROUP" \
+            --template-file infra/main.bicep \
+            --parameters infra/main.bicepparam || true
+      - name: apply
+        env:
+          CALIL_APP_KEY: ${{ secrets.CALIL_APP_KEY }}
+        run: |
+          az deployment group create \
+            --resource-group "$RESOURCE_GROUP" \
+            --template-file infra/main.bicep \
+            --parameters infra/main.bicepparam

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ swa-cli.config.json
 # Claude Code local settings
 .claude/
 .vite/
+
+# Bicep compiled output
+infra/*.json

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -52,6 +52,10 @@ npm run swa:start    # build → swa start dist --api-location api(既定 http:/
 
 ## デプロイ(Azure Static Web Apps)
 
+> インフラ(リソースグループ / Static Web App / アプリ設定)は **Bicep でコード管理**しています(#75)。
+> リソースの作成・更新は `infra/`(Bicep)を参照してください → [infra/README.md](infra/README.md)。
+> 以下の手順 1 は初期の手動作成記録で、現在は `infra/` の `what-if` / `create` で再現できます。
+
 ### 1. リソース作成 & キー登録
 1. Azure ポータルで **Static Web App** を作成(GitHub 連携)。
 2. 作成時のビルド設定(または `.github/workflows/azure-static-web-apps.yml` に反映済み):

--- a/docs/75-iac-bicep/design.md
+++ b/docs/75-iac-bicep/design.md
@@ -1,0 +1,76 @@
+# インフラの IaC 化（Bicep） — Design
+
+Issue: #75
+
+## Architecture Overview
+
+サブスクリプションスコープの `main.bicep` がリソースグループを宣言し、リソースはモジュールに分離する。初回は Static Web App モジュールのみ。将来の DB（#74）・Application Insights（#76）は同じ `modules/` に足していく。
+
+```mermaid
+flowchart TD
+  Param[main.bicepparam<br/>location/RG名/SWA名/＠secure calilAppKey] --> Main[main.bicep<br/>targetScope = subscription]
+  Main -->|resource| RG[(resourceGroup rg-libcheck)]
+  Main -->|module scope: rg| SWA[modules/staticWebApp.bicep]
+  SWA --> Site[Microsoft.Web/staticSites libcheck Free]
+  SWA --> Cfg[staticSites/config 'appsettings'<br/>CALIL_APP_KEY = secure param]
+  Future[future: modules/database.bicep / appInsights.bicep] -.-> Main
+```
+
+## File Layout
+
+```
+infra/
+  main.bicep                 # targetScope='subscription'：RG 作成 + モジュール呼び出し
+  main.bicepparam            # パラメータ（calilAppKey は readEnvironmentVariable で env から）
+  modules/
+    staticWebApp.bicep       # SWA 本体 + appsettings 子リソース
+  README.md                  # what-if / apply 手順、CI 自動適用の今後方針
+```
+
+## Component Design
+
+### `main.bicep`（subscription scope）
+- `targetScope = 'subscription'`
+- params: `location`（既定 `eastasia`）、`resourceGroupName`（`rg-libcheck`）、`staticWebAppName`（`libcheck`）、`@secure() calilAppKey`
+- `resource rg 'Microsoft.Resources/resourceGroups@2024-03-01'`（冪等）
+- `module swa 'modules/staticWebApp.bicep'`（`scope: rg`）へ name/location/calilAppKey を渡す
+- `output staticWebAppHostname`（モジュール出力を中継）
+
+### `modules/staticWebApp.bicep`（resource group scope）
+- `resource site 'Microsoft.Web/staticSites@2024-04-01'`：`sku { name:'Free', tier:'Free' }`、`properties: {}`（GitHub 連携プロパティは管理しない＝トークン方式の既存配信に干渉しない）
+- `resource appSettings 'Microsoft.Web/staticSites/config@2024-04-01'`：`parent: site`、`name: 'appsettings'`、`properties: { CALIL_APP_KEY: calilAppKey }`
+- `output defaultHostname = site.properties.defaultHostname`
+
+### `main.bicepparam`
+```bicep
+using './main.bicep'
+param location = 'eastasia'
+param resourceGroupName = 'rg-libcheck'
+param staticWebAppName = 'libcheck'
+param calilAppKey = readEnvironmentVariable('CALIL_APP_KEY')  // env から注入（リポジトリに値を置かない）
+```
+
+## デプロイフロー（手動 + what-if）
+
+```bash
+export CALIL_APP_KEY=...   # 値は api/local.settings.json 等から（コミットしない）
+# 差分プレビュー（破壊的変更が無いか確認）
+az deployment sub what-if  --location eastasia --template-file infra/main.bicep --parameters infra/main.bicepparam
+# 適用
+az deployment sub create   --location eastasia --template-file infra/main.bicep --parameters infra/main.bicepparam
+```
+
+## 安全性・冪等性
+- 既存 SWA と同名・同 location・同 SKU を宣言するため、`create` は in-place 更新（冪等）。
+- `appsettings` は全置換のため、毎回 `CALIL_APP_KEY` を渡す（NFR-1/制約）。値未設定なら `readEnvironmentVariable` がエラーで気づける。
+- **初回適用前に必ず `what-if`** を実行し、`repositoryUrl`/`branch` 等の差分が破壊的でないことを確認する（トークン方式の配信はこれらに依存しないため許容）。
+
+## 将来拡張（このIssueでは実装しない）
+- `modules/database.bicep`（#74 のDB）、`modules/appInsights.bicep`（#76 の効果測定）を追加し、`main.bicep` から呼ぶ。
+- 出力（接続文字列等）は SWA の appsettings へ secure に受け渡す設計余地を残す。
+
+## CI 自動適用の今後方針（整理のみ・別対応）
+- Azure AD でフェデレーション資格情報（OIDC）またはサービスプリンシパルを作成し、GitHub に登録。
+- `workflow_dispatch` / `infra/**` 変更の PR で `az deployment sub what-if`、`main` 反映で `create` を実行するワークフローを追加。
+- シークレットは GitHub Secrets（`CALIL_APP_KEY`）から `@secure()` パラメータへ注入。
+- 本対応では未実装。README に手順骨子のみ記載する。

--- a/docs/75-iac-bicep/design.md
+++ b/docs/75-iac-bicep/design.md
@@ -4,13 +4,12 @@ Issue: #75
 
 ## Architecture Overview
 
-サブスクリプションスコープの `main.bicep` がリソースグループを宣言し、リソースはモジュールに分離する。初回は Static Web App モジュールのみ。将来の DB（#74）・Application Insights（#76）は同じ `modules/` に足していく。
+**リソースグループスコープ**の `main.bicep` がリソースをモジュール経由で宣言する（最小権限：CI 用 ID は `rg-libcheck` の Contributor のみ）。リソースグループ自体は一度きりのブートストラップで作成済み。将来の DB（#74）・Application Insights（#76）は同じ `modules/` に足していく。
 
 ```mermaid
 flowchart TD
-  Param[main.bicepparam<br/>location/RG名/SWA名/＠secure calilAppKey] --> Main[main.bicep<br/>targetScope = subscription]
-  Main -->|resource| RG[(resourceGroup rg-libcheck)]
-  Main -->|module scope: rg| SWA[modules/staticWebApp.bicep]
+  Param[main.bicepparam<br/>location/SWA名/＠secure calilAppKey] --> Main[main.bicep<br/>targetScope = resourceGroup]
+  Main -->|module| SWA[modules/staticWebApp.bicep]
   SWA --> Site[Microsoft.Web/staticSites libcheck Free]
   SWA --> Cfg[staticSites/config 'appsettings'<br/>CALIL_APP_KEY = secure param]
   Future[future: modules/database.bicep / appInsights.bicep] -.-> Main
@@ -20,24 +19,24 @@ flowchart TD
 
 ```
 infra/
-  main.bicep                 # targetScope='subscription'：RG 作成 + モジュール呼び出し
+  main.bicep                 # targetScope='resourceGroup'：モジュール呼び出し
   main.bicepparam            # パラメータ（calilAppKey は readEnvironmentVariable で env から）
   modules/
     staticWebApp.bicep       # SWA 本体 + appsettings 子リソース
-  README.md                  # what-if / apply 手順、CI 自動適用の今後方針
+  README.md                  # what-if / apply 手順、CI、OIDC セットアップ手順
+.github/workflows/infra.yml  # CI: PR=what-if / main・手動=apply（production 承認ゲート）
 ```
 
 ## Component Design
 
-### `main.bicep`（subscription scope）
-- `targetScope = 'subscription'`
-- params: `location`（既定 `eastasia`）、`resourceGroupName`（`rg-libcheck`）、`staticWebAppName`（`libcheck`）、`@secure() calilAppKey`
-- `resource rg 'Microsoft.Resources/resourceGroups@2024-03-01'`（冪等）
-- `module swa 'modules/staticWebApp.bicep'`（`scope: rg`）へ name/location/calilAppKey を渡す
-- `output staticWebAppHostname`（モジュール出力を中継）
+### `main.bicep`（resource group scope）
+- `targetScope = 'resourceGroup'`
+- params: `location`（既定 `eastasia`）、`staticWebAppName`（`libcheck`）、`repositoryUrl`/`branch`（既存値を再表明）、`@secure() calilAppKey`
+- `module staticWebApp 'modules/staticWebApp.bicep'`（デプロイ先 RG にデプロイ）
+- `output staticWebAppHostname`
 
 ### `modules/staticWebApp.bicep`（resource group scope）
-- `resource site 'Microsoft.Web/staticSites@2024-04-01'`：`sku { name:'Free', tier:'Free' }`、`properties: {}`（GitHub 連携プロパティは管理しない＝トークン方式の既存配信に干渉しない）
+- `resource site 'Microsoft.Web/staticSites@2024-04-01'`：`sku { name:'Free', tier:'Free' }`、`properties: { provider, repositoryUrl, branch }`（既存値を再表明し settable フィールドの消失を防ぐ）
 - `resource appSettings 'Microsoft.Web/staticSites/config@2024-04-01'`：`parent: site`、`name: 'appsettings'`、`properties: { CALIL_APP_KEY: calilAppKey }`
 - `output defaultHostname = site.properties.defaultHostname`
 
@@ -45,32 +44,32 @@ infra/
 ```bicep
 using './main.bicep'
 param location = 'eastasia'
-param resourceGroupName = 'rg-libcheck'
 param staticWebAppName = 'libcheck'
 param calilAppKey = readEnvironmentVariable('CALIL_APP_KEY')  // env から注入（リポジトリに値を置かない）
 ```
 
-## デプロイフロー（手動 + what-if）
+## デプロイフロー
 
+手動・CI 共通の中核コマンド（RG スコープ）:
 ```bash
-export CALIL_APP_KEY=...   # 値は api/local.settings.json 等から（コミットしない）
-# 差分プレビュー（破壊的変更が無いか確認）
-az deployment sub what-if  --location eastasia --template-file infra/main.bicep --parameters infra/main.bicepparam
-# 適用
-az deployment sub create   --location eastasia --template-file infra/main.bicep --parameters infra/main.bicepparam
+az deployment group what-if --resource-group rg-libcheck --template-file infra/main.bicep --parameters infra/main.bicepparam
+az deployment group create  --resource-group rg-libcheck --template-file infra/main.bicep --parameters infra/main.bicepparam
 ```
 
+## CI 設計（`.github/workflows/infra.yml`）
+
+- 認証: **OIDC**（パスワードレス）。`azure/login@v2` + フェデレーション資格情報。
+  - PR の what-if ジョブ → subject `repo:satoryu/LibCheck:pull_request`
+  - apply ジョブ（`environment: production`）→ subject `repo:satoryu/LibCheck:environment:production`
+- トリガー: PR(`infra/**`)=what-if / `push: main`(`infra/**`)・`workflow_dispatch`=apply
+- 承認ゲート: `production` 環境に required reviewers。main 反映後も承認してから apply。
+- 権限: CI 用サービスプリンシパルは **`rg-libcheck` の Contributor のみ**（最小権限）。
+- シークレット: `CALIL_APP_KEY` は GitHub Secret → `env:` 経由で `@secure()` パラメータへ。
+
 ## 安全性・冪等性
-- 既存 SWA と同名・同 location・同 SKU を宣言するため、`create` は in-place 更新（冪等）。
-- `appsettings` は全置換のため、毎回 `CALIL_APP_KEY` を渡す（NFR-1/制約）。値未設定なら `readEnvironmentVariable` がエラーで気づける。
-- **初回適用前に必ず `what-if`** を実行し、`repositoryUrl`/`branch` 等の差分が破壊的でないことを確認する（トークン方式の配信はこれらに依存しないため許容）。
+- 既存 SWA と同名・同 location・同 SKU・同 settable プロパティを宣言するため、`create` は in-place 更新（冪等）。
+- `appsettings` は全置換のため、毎回 `CALIL_APP_KEY` を渡す。
+- what-if の残差（`stableInboundIP`/`trafficSplitting`/`deploymentAuthPolicy`）は無害なノイズ。`appsettings` は what-if 非対応（`x Unsupported`）。詳細は `infra/README.md`。
 
 ## 将来拡張（このIssueでは実装しない）
-- `modules/database.bicep`（#74 のDB）、`modules/appInsights.bicep`（#76 の効果測定）を追加し、`main.bicep` から呼ぶ。
-- 出力（接続文字列等）は SWA の appsettings へ secure に受け渡す設計余地を残す。
-
-## CI 自動適用の今後方針（整理のみ・別対応）
-- Azure AD でフェデレーション資格情報（OIDC）またはサービスプリンシパルを作成し、GitHub に登録。
-- `workflow_dispatch` / `infra/**` 変更の PR で `az deployment sub what-if`、`main` 反映で `create` を実行するワークフローを追加。
-- シークレットは GitHub Secrets（`CALIL_APP_KEY`）から `@secure()` パラメータへ注入。
-- 本対応では未実装。README に手順骨子のみ記載する。
+- `modules/database.bicep`（#74）、`modules/appInsights.bicep`（#76）を追加し `main.bicep` から呼ぶ。

--- a/docs/75-iac-bicep/requirements.md
+++ b/docs/75-iac-bicep/requirements.md
@@ -1,0 +1,41 @@
+# インフラの IaC 化（Bicep） — Requirements
+
+Issue: #75
+
+## Problem Statement
+
+現在 Azure のリソースは `az staticwebapp create` 等で手動作成されており、構成がコードに残っていない。今後 DB（#74）や効果測定（Application Insights, #76）などリソースが増えるため、インフラを **Bicep** でコード管理し、再現・追跡・拡張できるようにする。
+
+現状（実機確認済み）:
+- リソースグループ: `rg-libcheck`（`eastasia`）
+- Static Web App: `libcheck`（sku **Free**、`East Asia`、GitHub 連携、hostname `gray-mushroom-05e69e400.7.azurestaticapps.net`）
+- アプリ設定: `CALIL_APP_KEY`（シークレット）のみ
+
+## Requirements
+
+### Functional
+- FR-1: 既存リソース（`rg-libcheck` / SWA `libcheck` / sku Free）を Bicep で宣言的に再現できる。
+- FR-2: SWA のアプリ設定 `CALIL_APP_KEY` を Bicep の管理対象に含める（`@secure()` パラメータ）。
+- FR-3: `what-if`（差分プレビュー）→ `create`（適用）の手動デプロイ手順を用意する。
+- FR-4: 将来リソース（DB・Application Insights 等）をモジュールとして追加しやすい構成にする。
+
+### Non-Functional
+- NFR-1: シークレット（`CALIL_APP_KEY`）の値をリポジトリに置かない。デプロイ時に環境変数 / CI Secret から注入する。
+- NFR-2: 既存の本番 SWA を壊さない。適用前に必ず `what-if` で差分を確認する（誤適用防止）。
+- NFR-3: 冪等であること（同じテンプレートの再適用で意図しない変更が出ない）。
+- NFR-4: Bicep のビルド/リント（`az bicep build`）が通る。
+
+## Constraints
+- ARM の SWA アプリ設定（`appsettings`）は**全置換**。よってデプロイ時は毎回 `CALIL_APP_KEY` を渡す運用とする。
+- 本番デプロイ（アプリ配信）は既存の GitHub Actions（デプロイトークン方式）を継続。Bicep はインフラ構成を管理し、アプリ配信ワークフローには干渉しない。
+- CI からの自動適用には Azure への OIDC / サービスプリンシパル設定（Azure AD 側作業）が必要なため、**今回は手動適用**とし、CI 自動適用は後続（方針のみ整理）。
+
+## Acceptance Criteria
+- AC-1: `infra/` 配下の Bicep が `az bicep build` を通る。
+- AC-2: `az deployment sub what-if` を実行すると、既存リソースに対して破壊的変更が無い（差分が無い or 意図した差分のみ）ことを確認できる。
+- AC-3: `CALIL_APP_KEY` を環境変数から注入する形で、値がリポジトリに含まれない。
+- AC-4: README/DEPLOY 等に手動デプロイ手順と CI 自動適用の今後方針が記載される。
+
+## User Stories
+- US-1: 開発者として、インフラ構成をコードで把握・再現したい。手動操作の属人性をなくしたい。
+- US-2: 開発者として、新しいリソース（DB 等）を追加するとき、既存構成に倣ってモジュールを足すだけで済むようにしたい。

--- a/docs/75-iac-bicep/requirements.md
+++ b/docs/75-iac-bicep/requirements.md
@@ -28,13 +28,14 @@ Issue: #75
 ## Constraints
 - ARM の SWA アプリ設定（`appsettings`）は**全置換**。よってデプロイ時は毎回 `CALIL_APP_KEY` を渡す運用とする。
 - 本番デプロイ（アプリ配信）は既存の GitHub Actions（デプロイトークン方式）を継続。Bicep はインフラ構成を管理し、アプリ配信ワークフローには干渉しない。
-- CI からの自動適用には Azure への OIDC / サービスプリンシパル設定（Azure AD 側作業）が必要なため、**今回は手動適用**とし、CI 自動適用は後続（方針のみ整理）。
+- CI 自動適用は **OIDC（パスワードレス）+ 最小権限（`rg-libcheck` の Contributor のみ）+ `production` 環境の承認ゲート**で実装する。デプロイは RG スコープ（`az deployment group`）。
 
 ## Acceptance Criteria
 - AC-1: `infra/` 配下の Bicep が `az bicep build` を通る。
 - AC-2: `az deployment sub what-if` を実行すると、既存リソースに対して破壊的変更が無い（差分が無い or 意図した差分のみ）ことを確認できる。
 - AC-3: `CALIL_APP_KEY` を環境変数から注入する形で、値がリポジトリに含まれない。
-- AC-4: README/DEPLOY 等に手動デプロイ手順と CI 自動適用の今後方針が記載される。
+- AC-4: README/DEPLOY 等に手動デプロイ手順と CI 自動適用（OIDC・承認ゲート・OIDCセットアップ）が記載される。
+- AC-5: PR（`infra/**` 変更）で what-if ジョブが OIDC ログインしてグリーンになる。
 
 ## User Stories
 - US-1: 開発者として、インフラ構成をコードで把握・再現したい。手動操作の属人性をなくしたい。

--- a/docs/75-iac-bicep/tasks.md
+++ b/docs/75-iac-bicep/tasks.md
@@ -2,12 +2,26 @@
 
 Issue: #75
 
-- [x] `infra/modules/staticWebApp.bicep` を作成（SWA Free + appsettings 子リソース、secure param）
-- [x] `infra/main.bicep` を作成（subscription scope：RG + モジュール呼び出し、output hostname）
-- [x] `infra/main.bicepparam` を作成（calilAppKey は `readEnvironmentVariable`）
-- [x] `az bicep build` でビルド/リント通過を確認（警告なし）
-- [x] `az deployment sub what-if` で既存リソースへの破壊的変更が無いことを確認（残差は無害なノイズと特定）
-- [ ] （任意・要承認）`az deployment sub create` で実適用し冪等性を確認 ← 本番 SWA への適用のため、ユーザー判断を仰ぐ
-- [x] `infra/README.md` に手動デプロイ手順 + CI 自動適用の今後方針 + what-if 残差の説明を記載
-- [x] `DEPLOY.md` から `infra/` を参照（リソースはコード管理に移行した旨）
-- [ ] PR 作成・セルフレビュー
+## Bicep
+- [x] `infra/modules/staticWebApp.bicep`（SWA Free + appsettings 子リソース、secure param、settable プロパティ再表明）
+- [x] `infra/main.bicep`（**resource group スコープ**、モジュール呼び出し、output hostname）
+- [x] `infra/main.bicepparam`（calilAppKey は `readEnvironmentVariable`）
+- [x] `az bicep build` 警告なし通過
+- [x] `az deployment group what-if` で破壊的変更なしを確認（残差は無害ノイズと特定）
+
+## CI 自動適用（OIDC・最小権限・承認ゲート）
+- [x] Azure: App 登録 + SP + フェデレーション資格情報（pull_request / environment:production）
+- [x] Azure: ロール割当（Contributor @ rg-libcheck のみ＝最小権限）
+- [x] GitHub: Secrets（AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID / CALIL_APP_KEY）
+- [x] GitHub: `production` 環境 + required reviewers（承認ゲート）
+- [x] `.github/workflows/infra.yml`（PR=what-if / main・dispatch=apply）
+
+## ドキュメント
+- [x] `infra/README.md`（手動手順 + CI + OIDC セットアップ + what-if 残差）
+- [x] `DEPLOY.md` から `infra/` 参照、`infra/*.json` を gitignore
+- [x] `docs/75-iac-bicep/{requirements,design}.md` を最終構成に更新
+
+## 仕上げ
+- [ ] PR 更新・セルフレビュー
+- [ ] PR 上で what-if ジョブ（OIDC）がグリーンになることを確認
+- [ ] マージ後、apply ジョブ（承認 → 適用）で冪等性を確認

--- a/docs/75-iac-bicep/tasks.md
+++ b/docs/75-iac-bicep/tasks.md
@@ -1,0 +1,13 @@
+# インフラの IaC 化（Bicep） — Tasks
+
+Issue: #75
+
+- [x] `infra/modules/staticWebApp.bicep` を作成（SWA Free + appsettings 子リソース、secure param）
+- [x] `infra/main.bicep` を作成（subscription scope：RG + モジュール呼び出し、output hostname）
+- [x] `infra/main.bicepparam` を作成（calilAppKey は `readEnvironmentVariable`）
+- [x] `az bicep build` でビルド/リント通過を確認（警告なし）
+- [x] `az deployment sub what-if` で既存リソースへの破壊的変更が無いことを確認（残差は無害なノイズと特定）
+- [ ] （任意・要承認）`az deployment sub create` で実適用し冪等性を確認 ← 本番 SWA への適用のため、ユーザー判断を仰ぐ
+- [x] `infra/README.md` に手動デプロイ手順 + CI 自動適用の今後方針 + what-if 残差の説明を記載
+- [x] `DEPLOY.md` から `infra/` を参照（リソースはコード管理に移行した旨）
+- [ ] PR 作成・セルフレビュー

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,112 @@
+# infra — Bicep による IaC
+
+LibCheck の Azure リソースを [Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/) で管理する。Issue #75。
+
+## 管理対象
+
+| リソース | 種別 | 備考 |
+|---|---|---|
+| `rg-libcheck` | リソースグループ（`eastasia`） | `main.bicep`（subscription scope）で作成 |
+| `libcheck` | Static Web App（sku Free） | `modules/staticWebApp.bicep` |
+| `CALIL_APP_KEY` | SWA アプリ設定（シークレット） | `appsettings` 子リソース。値は注入（後述） |
+
+> アプリ（フロントエンド）の配信は別系統。既存の GitHub Actions（`.github/workflows/azure-static-web-apps.yml`、デプロイトークン方式）が担う。Bicep は **インフラ構成のみ** を管理し、配信ワークフローには干渉しない。
+
+## ファイル構成
+
+```
+infra/
+  main.bicep              # targetScope='subscription'：RG 作成 + モジュール呼び出し
+  main.bicepparam         # パラメータ（calilAppKey は環境変数から注入）
+  modules/
+    staticWebApp.bicep    # SWA 本体 + appsettings 子リソース
+  README.md               # このファイル
+```
+
+## 前提
+
+- Azure CLI（`az`）にログイン済みで、対象サブスクリプションが選択されていること
+  ```bash
+  az login
+  az account show   # 対象サブスクリプションを確認
+  ```
+- Bicep CLI（`az` に同梱。未導入なら `az bicep install`）
+- シークレット `CALIL_APP_KEY` を環境変数で渡せること（リポジトリには置かない）
+  ```bash
+  # 例: ローカルの api/local.settings.json から取り出す（値は表示しない）
+  export CALIL_APP_KEY="$(python3 -c "import json;print(json.load(open('api/local.settings.json'))['Values']['CALIL_APP_KEY'])")"
+  ```
+
+## 手動デプロイ手順（CI 化でもそのまま使えるコマンド）
+
+> 以下の `what-if` / `create` の 2 コマンドが手動・CI 共通の中核。CI 化の際は「az login を OIDC に置き換える」「`CALIL_APP_KEY` を GitHub Secret から渡す」だけで同じコマンドを使える。
+
+### 1. ビルド / リント
+
+```bash
+az bicep build --file infra/main.bicep
+```
+
+### 2. what-if（差分プレビュー・適用前に必須）
+
+```bash
+az deployment sub what-if \
+  --location eastasia \
+  --template-file infra/main.bicep \
+  --parameters infra/main.bicepparam
+```
+
+- 既存リソースに対して **破壊的変更が無い**（差分なし、または意図した差分のみ）ことを確認する。
+- `CALIL_APP_KEY` は `@secure()` のため what-if 出力では値がマスクされる。
+
+### 3. apply（適用）
+
+```bash
+az deployment sub create \
+  --location eastasia \
+  --template-file infra/main.bicep \
+  --parameters infra/main.bicepparam
+```
+
+## what-if の残差（無害なノイズ）について
+
+既存 SWA に対する `what-if` では、以下が差分として表示されるが**いずれも無害**：
+
+- `properties.stableInboundIP` / `properties.trafficSplitting` … サーバー側で計算・既定設定される読み取り専用相当の値。テンプレートでは制御せず、Azure が再設定する（what-if の既知の false positive ノイズ）。
+- `properties.deploymentAuthPolicy: "DeploymentToken"` … 省略しても apply 後に既定値 `DeploymentToken` に戻り同値。明示するには未定義プロパティ（BCP037）になるため設定しない。
+- `config/appsettings` … `x Unsupported`。SWA の appsettings は GET 非対応のため what-if で差分プレビューできない。`CALIL_APP_KEY` を毎回渡すため、適用後は現行と同じ単一キー構成になる。
+
+`provider` / `repositoryUrl` / `branch` は既存値を再表明しているため差分なし。settable で意味のあるプロパティが失われないことを確認済み。
+
+## 注意・冪等性
+
+- SWA の `appsettings` は **ARM 上で全置換**。よってデプロイ時は毎回 `CALIL_APP_KEY` を渡すこと。
+  未設定だと `main.bicepparam` の `readEnvironmentVariable('CALIL_APP_KEY')` がエラーになり気づける。
+- 既存リソースと同名・同 location・同 SKU を宣言するため、`create` は in-place 更新（冪等）。
+- 初回適用前は必ず `what-if` で差分を確認すること。
+
+## CI 自動適用の今後方針（#75 では未実装・整理のみ）
+
+OIDC 整備後に GitHub Actions へ載せる。手動手順との差分は **認証** と **シークレットの渡し方** のみ。
+
+1. **認証**: Azure AD でフェデレーション資格情報（OIDC）またはサービスプリンシパルを作成し、`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` を GitHub に登録。
+   ```yaml
+   permissions:
+     id-token: write
+     contents: read
+   steps:
+     - uses: azure/login@v2
+       with:
+         client-id: ${{ secrets.AZURE_CLIENT_ID }}
+         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+   ```
+2. **what-if（PR / `infra/**` 変更時）→ apply（`main` 反映時）**:
+   ```yaml
+   - name: what-if
+     run: az deployment sub what-if --location eastasia --template-file infra/main.bicep --parameters infra/main.bicepparam
+     env:
+       CALIL_APP_KEY: ${{ secrets.CALIL_APP_KEY }}
+   ```
+   apply は `az deployment sub create ...` を同様に。`CALIL_APP_KEY` は GitHub Secret から `env` で渡す。
+3. アプリ配信ワークフロー（azure-static-web-apps.yml）とは別ワークフローにし、責務を分離する。

--- a/infra/README.md
+++ b/infra/README.md
@@ -37,9 +37,19 @@ infra/
   export CALIL_APP_KEY="$(python3 -c "import json;print(json.load(open('api/local.settings.json'))['Values']['CALIL_APP_KEY'])")"
   ```
 
-## 手動デプロイ手順（CI 化でもそのまま使えるコマンド）
+## デプロイスコープ
 
-> 以下の `what-if` / `create` の 2 コマンドが手動・CI 共通の中核。CI 化の際は「az login を OIDC に置き換える」「`CALIL_APP_KEY` を GitHub Secret から渡す」だけで同じコマンドを使える。
+リソースグループスコープでデプロイする（最小権限）。リソースグループ `rg-libcheck`
+は一度きりのブートストラップで作成済み（IaC では作成しない）。
+
+```bash
+# ブートストラップ（初回のみ・作成済み）
+az group create --name rg-libcheck --location eastasia
+```
+
+## 手動デプロイ手順（CI でも同じコマンドを使う）
+
+> 以下の `what-if` / `create` の 2 コマンドが手動・CI 共通の中核。CI では「`az login` を OIDC に置き換える」「`CALIL_APP_KEY` を GitHub Secret から渡す」だけで同じコマンドを使う（`.github/workflows/infra.yml`）。
 
 ### 1. ビルド / リント
 
@@ -50,8 +60,8 @@ az bicep build --file infra/main.bicep
 ### 2. what-if（差分プレビュー・適用前に必須）
 
 ```bash
-az deployment sub what-if \
-  --location eastasia \
+az deployment group what-if \
+  --resource-group rg-libcheck \
   --template-file infra/main.bicep \
   --parameters infra/main.bicepparam
 ```
@@ -62,8 +72,8 @@ az deployment sub what-if \
 ### 3. apply（適用）
 
 ```bash
-az deployment sub create \
-  --location eastasia \
+az deployment group create \
+  --resource-group rg-libcheck \
   --template-file infra/main.bicep \
   --parameters infra/main.bicepparam
 ```
@@ -85,28 +95,47 @@ az deployment sub create \
 - 既存リソースと同名・同 location・同 SKU を宣言するため、`create` は in-place 更新（冪等）。
 - 初回適用前は必ず `what-if` で差分を確認すること。
 
-## CI 自動適用の今後方針（#75 では未実装・整理のみ）
+## CI 自動適用（`.github/workflows/infra.yml`）
 
-OIDC 整備後に GitHub Actions へ載せる。手動手順との差分は **認証** と **シークレットの渡し方** のみ。
+OIDC（パスワードレス）で Azure にログインして適用する。アプリ配信ワークフロー
+（azure-static-web-apps.yml）とは責務を分離している。
 
-1. **認証**: Azure AD でフェデレーション資格情報（OIDC）またはサービスプリンシパルを作成し、`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` を GitHub に登録。
-   ```yaml
-   permissions:
-     id-token: write
-     contents: read
-   steps:
-     - uses: azure/login@v2
-       with:
-         client-id: ${{ secrets.AZURE_CLIENT_ID }}
-         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-   ```
-2. **what-if（PR / `infra/**` 変更時）→ apply（`main` 反映時）**:
-   ```yaml
-   - name: what-if
-     run: az deployment sub what-if --location eastasia --template-file infra/main.bicep --parameters infra/main.bicepparam
-     env:
-       CALIL_APP_KEY: ${{ secrets.CALIL_APP_KEY }}
-   ```
-   apply は `az deployment sub create ...` を同様に。`CALIL_APP_KEY` は GitHub Secret から `env` で渡す。
-3. アプリ配信ワークフロー（azure-static-web-apps.yml）とは別ワークフローにし、責務を分離する。
+| トリガー | 動作 |
+|---|---|
+| `pull_request`（`infra/**`） | **what-if** のみ（差分プレビュー・読み取り） |
+| `push: main`（`infra/**`） | **apply**（`production` 環境の承認ゲート経由） |
+| `workflow_dispatch` | **apply**（同上・初回/再適用/手動） |
+
+`production` 環境に **required reviewers** を設定しているため、main 反映後も承認操作を
+してから apply が実行される（本番リソースの誤適用防止）。
+
+### 一度きりのセットアップ（実施済み・再現用メモ）
+
+```bash
+# 1) GitHub OIDC 用の App 登録 + サービスプリンシパル
+az ad app create --display-name libcheck-github-oidc          # → appId(=AZURE_CLIENT_ID)
+az ad sp create --id <appId>
+
+# 2) フェデレーション資格情報（トリガーごとに subject を登録）
+#    - PR の what-if 用 : repo:satoryu/LibCheck:pull_request
+#    - apply 用(環境)   : repo:satoryu/LibCheck:environment:production
+az ad app federated-credential create --id <appId> --parameters '{
+  "name":"github-pull-request","issuer":"https://token.actions.githubusercontent.com",
+  "subject":"repo:satoryu/LibCheck:pull_request","audiences":["api://AzureADTokenExchange"]}'
+az ad app federated-credential create --id <appId> --parameters '{
+  "name":"github-env-production","issuer":"https://token.actions.githubusercontent.com",
+  "subject":"repo:satoryu/LibCheck:environment:production","audiences":["api://AzureADTokenExchange"]}'
+
+# 3) 最小権限のロール割当（rg-libcheck のみ）
+az role assignment create --assignee <appId> --role Contributor \
+  --scope /subscriptions/<subId>/resourceGroups/rg-libcheck
+
+# 4) GitHub 側: Secrets と Environment
+gh secret set AZURE_CLIENT_ID --body <appId>
+gh secret set AZURE_TENANT_ID --body <tenantId>
+gh secret set AZURE_SUBSCRIPTION_ID --body <subId>
+gh secret set CALIL_APP_KEY --body <calil-app-key>     # @secure() パラメータへ
+# production 環境 + required reviewers は gh api で作成済み
+```
+
+> シークレットは GitHub Secrets に保存し、ワークフローでは `env:` 経由で `@secure()` パラメータへ渡す。OIDC のためクライアントシークレット（パスワード）は発行しない。

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,10 +1,10 @@
-targetScope = 'subscription'
+// リソースグループスコープでデプロイする（最小権限：CI 用 ID は rg-libcheck の
+// Contributor のみで足りる）。RG 自体は一度きりのブートストラップで作成済みのため、
+// ここでは作成しない。
+targetScope = 'resourceGroup'
 
 @description('リソースのリージョン')
 param location string = 'eastasia'
-
-@description('リソースグループ名')
-param resourceGroupName string = 'rg-libcheck'
 
 @description('Static Web App の名前')
 param staticWebAppName string = 'libcheck'
@@ -19,14 +19,8 @@ param branch string = 'main'
 @secure()
 param calilAppKey string
 
-resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
-  name: resourceGroupName
-  location: location
-}
-
 module staticWebApp 'modules/staticWebApp.bicep' = {
   name: 'staticWebApp'
-  scope: rg
   params: {
     name: staticWebAppName
     location: location

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,40 @@
+targetScope = 'subscription'
+
+@description('リソースのリージョン')
+param location string = 'eastasia'
+
+@description('リソースグループ名')
+param resourceGroupName string = 'rg-libcheck'
+
+@description('Static Web App の名前')
+param staticWebAppName string = 'libcheck'
+
+@description('GitHub 連携: リポジトリ URL（既存リソースに合わせる）')
+param repositoryUrl string = 'https://github.com/satoryu/LibCheck'
+
+@description('GitHub 連携: ブランチ')
+param branch string = 'main'
+
+@description('Calil API アプリキー（シークレット）。リポジトリに置かず、デプロイ時に注入する。')
+@secure()
+param calilAppKey string
+
+resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+module staticWebApp 'modules/staticWebApp.bicep' = {
+  name: 'staticWebApp'
+  scope: rg
+  params: {
+    name: staticWebAppName
+    location: location
+    repositoryUrl: repositoryUrl
+    branch: branch
+    calilAppKey: calilAppKey
+  }
+}
+
+@description('Static Web App の既定ホスト名')
+output staticWebAppHostname string = staticWebApp.outputs.defaultHostname

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -1,9 +1,8 @@
 using './main.bicep'
 
 param location = 'eastasia'
-param resourceGroupName = 'rg-libcheck'
 param staticWebAppName = 'libcheck'
 
 // シークレットはリポジトリに置かず、デプロイ実行時の環境変数 CALIL_APP_KEY から注入する。
-// （CI 化の際も同名の環境変数 / Secret を渡せばそのまま使える）
+// （CI でも同名の GitHub Secret を env で渡せばそのまま使える）
 param calilAppKey = readEnvironmentVariable('CALIL_APP_KEY')

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -1,0 +1,9 @@
+using './main.bicep'
+
+param location = 'eastasia'
+param resourceGroupName = 'rg-libcheck'
+param staticWebAppName = 'libcheck'
+
+// シークレットはリポジトリに置かず、デプロイ実行時の環境変数 CALIL_APP_KEY から注入する。
+// （CI 化の際も同名の環境変数 / Secret を渡せばそのまま使える）
+param calilAppKey = readEnvironmentVariable('CALIL_APP_KEY')

--- a/infra/modules/staticWebApp.bicep
+++ b/infra/modules/staticWebApp.bicep
@@ -1,0 +1,51 @@
+@description('Static Web App の名前')
+param name string
+
+@description('リージョン（Static Web App Free が利用可能なリージョン）')
+param location string
+
+@description('Calil API アプリキー（シークレット）。リポジトリに置かず、デプロイ時に注入する。')
+@secure()
+param calilAppKey string
+
+@description('GitHub 連携プロバイダ（既存リソースに合わせる）')
+param provider string = 'GitHub'
+
+@description('GitHub 連携: リポジトリ URL')
+param repositoryUrl string = 'https://github.com/satoryu/LibCheck'
+
+@description('GitHub 連携: ブランチ')
+param branch string = 'main'
+
+resource site 'Microsoft.Web/staticSites@2024-04-01' = {
+  name: name
+  location: location
+  sku: {
+    name: 'Free'
+    tier: 'Free'
+  }
+  // 既存リソースの設定可能プロパティを再表明し、apply が settable フィールドを
+  // 消さない（実質 no-op になる）ようにする。アプリ配信は既存の GitHub Actions
+  // （デプロイトークン方式）が担い、ここでは構成のみを忠実に表現する。
+  // 注: deploymentAuthPolicy は省略。apply 後に既定の 'DeploymentToken' に戻り
+  // 同値となるため害はなく、現行 Bicep 型では未定義（BCP037）のため明示しない。
+  properties: {
+    provider: provider
+    repositoryUrl: repositoryUrl
+    branch: branch
+  }
+}
+
+// SWA のアプリ設定（Azure Functions プロキシが process.env から参照）。
+// ARM では appsettings は全置換のため、管理するキーはここに網羅する。
+// 値はデプロイ時に @secure() パラメータ経由で注入し、リポジトリには残さない。
+resource appSettings 'Microsoft.Web/staticSites/config@2024-04-01' = {
+  parent: site
+  name: 'appsettings'
+  properties: {
+    CALIL_APP_KEY: calilAppKey
+  }
+}
+
+@description('SWA の既定ホスト名')
+output defaultHostname string = site.properties.defaultHostname


### PR DESCRIPTION
Closes #75

## 概要
既存の Azure リソース（リソースグループ `rg-libcheck` / Static Web App `libcheck`・Free）を **Bicep** で宣言的にコード管理できるようにしました。今後の DB(#74)・Application Insights(#76) をモジュールとして追加しやすい構成です。

## 方針（事前合意）
- `CALIL_APP_KEY`（SWAアプリ設定＝シークレット）は `@secure()` パラメータで管理。**値はリポジトリに置かず**、デプロイ時に環境変数 `CALIL_APP_KEY` から注入。
- 適用は **手動 + `what-if`**。CI 自動適用は OIDC 整備後の後続（`infra/README.md` に方針を記載、手順はそのまま流用可能）。
- アプリ配信（既存の `azure-static-web-apps.yml`・デプロイトークン方式）には干渉しない。

## 構成
```
infra/
  main.bicep            # subscription scope: RG + staticWebApp モジュール
  main.bicepparam       # calilAppKey は readEnvironmentVariable で env から
  modules/
    staticWebApp.bicep  # SWA(Free) + appsettings(CALIL_APP_KEY=secure)
  README.md             # 手動デプロイ手順 + CI化方針 + what-if残差の説明
```
ドキュメント: `docs/75-iac-bicep/{requirements,design,tasks}.md`

## what-if 結果（既存リソースへの破壊的変更なし）
- `rg-libcheck` … No change
- `staticSites/libcheck` … `provider`/`repositoryUrl`/`branch` は既存値を再表明し差分なし。残差は **無害なノイズ**のみ：
  - `stableInboundIP` / `trafficSplitting` … サーバー計算値（what-if の既知 false positive）
  - `deploymentAuthPolicy` … 省略しても既定 `DeploymentToken` に戻り同値（明示は BCP037 のため避ける）
- `config/appsettings` … `x Unsupported`（SWA の appsettings は what-if 非対応）。`CALIL_APP_KEY` を毎回渡すため適用後は現行と同一の単一キー構成。

## Test Plan
- [x] `az bicep build` 警告なしで通過
- [x] `az deployment sub what-if` で破壊的変更なしを確認（残差ノイズを特定・文書化）
- [ ] （任意・要承認）`az deployment sub create` で実適用し冪等性を確認 ※本番 SWA への変更のため申請者判断
- [x] シークレット値がリポジトリ／コミットに含まれないことを確認（`infra/*.json` も gitignore）

> 注: 実 `create` 適用は本番 SWA への変更（かつ appsettings は what-if 非対応）のため、このPRには含めず別途実施判断とします。マージ自体はインフラ構成のコード化のみで安全です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)