### PR TITLE
docs(wrangler): GOOGLE_CLIENT_ID を secret_text で持つ理由を明記

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,6 +5,10 @@ pages_build_output_dir = "dist"
 # GOOGLE_CLIENT_ID は Pages プロジェクトの環境変数（プロジェクトレベル）で管理する。
 # wrangler.toml の [vars] に重複定義すると deploy 時に「binding already in use」で
 # 失敗するため、ここには置かない（公開値だが管理場所をプロジェクト側に一本化）。
+# 注意: プロジェクト側でも「プレーン変数」で持つと wrangler pages deploy が
+# [vars] を正本とみなして消してしまう（→ env.GOOGLE_CLIENT_ID 空で /api/me が500）。
+# そのため CALIL_APP_KEY と同様に「シークレット（secret_text）」で登録し、
+# デプロイをまたいで保持させる。
 
 # 登録図書館・検索履歴の永続化先（#74）。env.DB として Functions から参照。
 # CALIL_APP_KEY はシークレットのため wrangler.toml には置かず、Pages の


### PR DESCRIPTION
## 概要

#74（登録図書館・検索履歴の D1 永続化）の本番化で踏んだ環境変数の罠を、再発防止のため `wrangler.toml` のコメントに残す。

## 背景 / 何が起きたか

- `wrangler pages deploy`（CI の `cloudflare/wrangler-action` 経由含む）は `wrangler.toml` の `[vars]` を **プレーン環境変数の正本**とみなし、そこに無いプレーン変数をデプロイ時に削除する。
- Cloudflare API で `GOOGLE_CLIENT_ID` を `plain_text` として設定していたため、再デプロイで消失 → `env.GOOGLE_CLIENT_ID` が空 → `/api/me` のトークン検証が **500**。
- `CALIL_APP_KEY` は `secret_text` だったためデプロイをまたいで保持されていた。

## 対処（実施済み・本番反映済み）

- `GOOGLE_CLIENT_ID` を `secret_text` で再登録 → 再デプロイ。
- 検証: `/api/me` 偽/無トークン → **401**、Calil プロキシ → **200**。PC↔モバイルの同期も確認済み。

本 PR はその方針をコメントとして明文化するドキュメント変更のみ（挙動変更なし）。

## Test Plan

- [x] コメントのみの変更で挙動に影響しないこと（差分目視）
- [x] 本番 `/api/me` が 401（検証機能）/ Calil 200（回帰なし）であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)