### PR TITLE
D1 スキーマのマイグレーション運用化（#83）

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -28,6 +28,15 @@ jobs:
           # Google OAuth クライアント ID（公開値）。GIS のログインに使う。
           VITE_GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
         run: npm run build
+      # スキーマ→コードの順序を保証するため、デプロイの「前」に本番 D1 へ
+      # マイグレーションを適用する（#83）。適用済みは d1_migrations 表で判定され
+      # 冪等にスキップ。ここが失敗すると後続の deploy には進まない。
+      - name: Apply D1 migrations (remote)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: d1 migrations apply libcheck --remote
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:

--- a/.github/workflows/d1-migrate.yml
+++ b/.github/workflows/d1-migrate.yml
@@ -1,0 +1,26 @@
+name: D1 migrations (validate)
+
+# PR 時にマイグレーションの妥当性だけを検証する（本番 D1 には触れない）。
+# 本番への適用（--remote）はデプロイ順序を保証するため cloudflare-pages.yml の
+# デプロイ前ステップで行う（#83）。
+on:
+  pull_request:
+    paths:
+      - 'infra/d1/migrations/**'
+      - 'wrangler.toml'
+      - '.github/workflows/d1-migrate.yml'
+
+jobs:
+  validate:
+    name: apply --local (dry validation)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # 一時的なローカル SQLite にマイグレーションを適用し、SQL の妥当性・
+      # 連番の整合を確認する。--local はローカル状態のみを使い API を呼ばない。
+      - name: Apply D1 migrations (local)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: d1 migrations apply libcheck --local

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -8,11 +8,13 @@ on:
   pull_request:
     paths:
       - 'infra/**'
+      - '!infra/d1/**' # D1 スキーマは Azure Bicep と無関係（#83。適用は cloudflare-pages.yml / d1-migrate.yml）
       - '.github/workflows/infra.yml'
   push:
     branches: [main]
     paths:
       - 'infra/**'
+      - '!infra/d1/**' # D1 スキーマは Azure Bicep と無関係（#83。適用は cloudflare-pages.yml / d1-migrate.yml）
       - '.github/workflows/infra.yml'
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tsconfig.tsbuildinfo
 vite.config.js
 vite.config.d.ts
 vite-dev-persistence.d.ts
+vite-dev-migrations.d.ts
 /coverage/
 
 # Azure Functions (API) local secrets & build artifacts

--- a/docs/83-d1-migrations/design.md
+++ b/docs/83-d1-migrations/design.md
@@ -1,0 +1,130 @@
+# #83 D1 スキーマのマイグレーション運用化 — Design
+
+## Architecture Overview
+
+`wrangler d1 migrations` を正本とする。マイグレーションファイルは `infra/d1/migrations/` に連番で置き、wrangler が D1 内の `d1_migrations` テーブルで適用済みを追跡する。本番適用は **CI（デプロイ直前）** で、ローカルは dev プラグインが同じファイル群を適用する。
+
+```mermaid
+flowchart TD
+  subgraph repo[リポジトリ]
+    M[infra/d1/migrations/NNNN_*.sql]
+    W[wrangler.toml: migrations_dir]
+  end
+
+  subgraph pr[PR 時]
+    V[d1-migrate.yml: validate\nwrangler d1 migrations apply --local]
+  end
+
+  subgraph main[main マージ時]
+    A[cloudflare-pages.yml\nStep1: migrations apply --remote]
+    D[Step2: pages deploy]
+    A --> D
+  end
+
+  subgraph local[ローカル npm run dev]
+    P[vite-dev-persistence.ts\napplyMigrations 順次適用]
+    S[(.dev.d1.sqlite)]
+    P --> S
+  end
+
+  M --> V
+  M --> A
+  M --> P
+  W --> A
+  W --> P
+```
+
+設計上の要点:
+
+- **適用はデプロイ前**（同一ジョブ内の前段ステップ）。別ワークフローに分けると push 時に並走して順序が崩れるため、`cloudflare-pages.yml` に同居させて「スキーマ→コード」を保証する（NFR-1）。
+- **冪等**: `wrangler d1 migrations apply` は適用済みを `d1_migrations` で判定しスキップする。毎 push 走っても未適用が無ければ no-op（FR-3, AC-3）。
+- **検証は本番に触れない**: PR では `--local`（一時 SQLite）に適用して SQL の妥当性のみ確認する（FR-4, AC-4）。
+- **wrangler はローカル導入しない**: CI では `cloudflare/wrangler-action@v3`（デプロイで実績あり）を使い、過去に詰まった sharp ネイティブビルドを回避する（NFR-3）。
+
+## Component Design
+
+### 1. マイグレーションファイル `infra/d1/migrations/0001_init.sql`
+
+現行 `schema.sql` をベースラインとして移す。`CREATE TABLE IF NOT EXISTS` を維持し、既に同テーブルを持つ本番 D1 に冪等適用できるようにする（Constraints）。
+
+> **ベースラインの注意**: 既存本番 D1 は migrations 導入前に手動適用されており `d1_migrations` 表が無い。初回 `migrations apply --remote` で wrangler は `0001` を「未適用」とみなし実行するが、`IF NOT EXISTS` のため実テーブルは no-op で、wrangler は `0001` を適用済みとして記録する。以降は通常どおり差分適用される。
+
+### 2. `wrangler.toml`
+
+```toml
+[[d1_databases]]
+binding = "DB"
+database_name = "libcheck"
+database_id = "ba647dce-..."
+migrations_dir = "infra/d1/migrations"
+```
+
+### 3. dev プラグイン `vite-dev-persistence.ts`
+
+`schema.sql` 単一読み込みを、`infra/d1/migrations/` 配下の `*.sql` を**連番順に**読み適用する形へ変更する。順序・コメント除去・文分割のロジックを純粋関数 `orderedMigrationStatements()` に切り出し、ユニットテスト可能にする（TDD 対象）。
+
+```ts
+// 純粋関数: マイグレーションファイル群 → 実行する SQL 文の配列（連番順）
+export function orderedMigrationStatements(
+  files: { name: string; content: string }[],
+): string[]
+```
+
+- `.sql` のみ対象、ファイル名の数値プレフィックス昇順、`--` コメント行を除去、`;` で文分割し空を捨てる。
+- dev プラグインはこの結果を `db.exec(stmt)` で順に流す。`d1_migrations` 追跡はローカルでは不要（毎回 `IF NOT EXISTS` で冪等構築する方針）。
+
+### 4. CI
+
+#### `cloudflare-pages.yml`（main / workflow_dispatch）— 適用 + デプロイ
+
+build の後・deploy の前に「Apply D1 migrations (remote)」ステップを追加:
+
+```yaml
+- name: Apply D1 migrations (remote)
+  uses: cloudflare/wrangler-action@v3
+  with:
+    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    command: d1 migrations apply libcheck --remote
+- name: Deploy to Cloudflare Pages
+  uses: cloudflare/wrangler-action@v3
+  with: { ... command: pages deploy }
+```
+
+適用が失敗するとジョブが落ち、deploy ステップに進まない（NFR-2）。
+
+#### `d1-migrate.yml`（PR）— 検証のみ
+
+`infra/d1/migrations/**` または当ワークフロー変更の PR で、`--local` 適用により SQL を検証:
+
+```yaml
+on:
+  pull_request:
+    paths: ['infra/d1/migrations/**', '.github/workflows/d1-migrate.yml', 'wrangler.toml']
+jobs:
+  validate:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: d1 migrations apply libcheck --local
+```
+
+`--local` は一時 SQLite を作って適用するだけで本番 D1 に触れない（FR-4）。
+
+### 5. ドキュメント
+
+`infra/d1/README.md` に「新しいマイグレーションの追加手順」を記載（ファイル命名規約 `NNNN_説明.sql`、ローカル確認、PR→main で自動適用される流れ、ベースラインの注意）。
+
+## Data Flow
+
+1. 開発者が `infra/d1/migrations/000N_*.sql` を追加して PR。
+2. PR: `d1-migrate.yml` が `--local` 適用で SQL を検証。`ci.yml` が型・テスト。
+3. マージ: `cloudflare-pages.yml` が `--remote` 適用（未適用のみ・冪等）→ `pages deploy`。
+4. ローカル: `npm run dev` 起動時に dev プラグインが migrations を順次適用し `.dev.d1.sqlite` を構築。
+
+## Domain Models
+
+スキーマ定義（`registered_libraries` / `search_history`）は #74 のまま不変。本 issue は**スキーマの管理・適用方法**の変更であり、ドメインモデルやアプリコード（`src/`）には変更を加えない。

--- a/docs/83-d1-migrations/requirements.md
+++ b/docs/83-d1-migrations/requirements.md
@@ -1,0 +1,49 @@
+# #83 D1 スキーマのマイグレーション運用化 — Requirements
+
+## Problem Statement
+
+#74 で登録図書館・検索履歴を Cloudflare D1 に永続化した。スキーマは `infra/d1/schema.sql` を手動で `wrangler d1 execute --remote --file` 適用する運用になっている。これには次の課題がある。
+
+- **追跡性の欠如**: スキーマ変更の履歴と「どこまで適用済みか」が記録されない。
+- **再現性・安全性の低さ**: 本番適用が手動で、人為ミス・適用漏れ・二重適用のリスクがある。
+- **経路の分散**: ローカル（`vite-dev-persistence.ts` が `schema.sql` を読む）と本番で、スキーマの管理経路が別々。
+
+## Requirements
+
+### Functional
+
+- FR-1: スキーマ変更を連番マイグレーションファイル（`NNNN_*.sql`）として管理する。
+- FR-2: main へのマージで、本番 D1 に未適用のマイグレーションが自動適用される。
+- FR-3: 適用済みマイグレーションは冪等にスキップされる（再実行で副作用がない）。
+- FR-4: PR 時に、マイグレーションが正しい SQL として適用できることを本番に触れずに検証する。
+- FR-5: ローカル開発（`npm run dev`）が、同じマイグレーション群から同一スキーマを構築する。
+- FR-6: 新しいマイグレーションの追加手順がドキュメント化されている。
+
+### Non-Functional
+
+- NFR-1: 本番への適用は**コードのデプロイより前**に完了し、スキーマ→コードの順序を保証する。
+- NFR-2: マイグレーション適用に失敗した場合、デプロイは進まない（失敗が握りつぶされない）。
+- NFR-3: CI はローカルへの `wrangler` グローバルインストール（過去に sharp のネイティブビルドで失敗）に依存しない。
+
+## Constraints
+
+- 既存の本番 D1（`database_id = ba647dce-...`）には既に `registered_libraries` / `search_history` が存在する。最初のマイグレーション（ベースライン）はこの既存 DB に**冪等適用**できる必要がある（`CREATE TABLE IF NOT EXISTS` を維持）。
+- CI からの本番適用は既存の `secrets.CLOUDFLARE_API_TOKEN` / `secrets.CLOUDFLARE_ACCOUNT_ID` を用いる（新規シークレットを増やさない）。
+- 既存の `cloudflare-pages.yml`（デプロイ）/ `ci.yml`（型・テスト）の責務を壊さない。
+- ローカルの永続化テスト（vitest）は `--experimental-sqlite` 無しでも壊れない（現状の no-op ガードを維持）。
+
+## Acceptance Criteria
+
+- AC-1: `infra/d1/migrations/0001_init.sql` が存在し、現行スキーマと等価。`schema.sql` は廃止または移行される。
+- AC-2: `wrangler.toml` の `[[d1_databases]]` に `migrations_dir` が設定されている。
+- AC-3: main マージで本番 D1 にマイグレーションが自動適用される（既存テーブルに対しては冪等で no-op）。
+- AC-4: PR で、わざと壊した SQL を含めると CI が失敗する（正しい SQL では成功する）。
+- AC-5: `npm run dev` がマイグレーション経由で `registered_libraries` / `search_history` を構築し、#74 の永続化が従来どおり動く。
+- AC-6: マイグレーション追加手順のドキュメントがある。
+- AC-7: `npx tsc -b` と `npm test` が緑。
+
+## User Stories
+
+- 開発者として、スキーマ変更を連番ファイルとして PR に含めたい。レビューで差分が見え、マージで自動適用されるため。
+- 開発者として、PR の段階で SQL の誤りに気づきたい。本番に壊れた変更を持ち込まないため。
+- 運用者として、本番 D1 のスキーマが「どのマイグレーションまで適用済みか」を把握したい。手作業の適用漏れをなくすため。

--- a/docs/83-d1-migrations/tasks.md
+++ b/docs/83-d1-migrations/tasks.md
@@ -1,0 +1,16 @@
+# #83 D1 スキーマのマイグレーション運用化 — Tasks
+
+TDD（失敗するテスト→実装→リファクタ）で進める。
+
+- [x] 1. `orderedMigrationStatements()` の失敗するテストを書く（連番順・`.sql`のみ・コメント除去・文分割）
+- [x] 2. `orderedMigrationStatements()` を実装し、テストを緑にする
+- [x] 3. `infra/d1/migrations/0001_init.sql` を作成（現行 schema.sql 等価・`IF NOT EXISTS` 維持）
+- [x] 4. `infra/d1/schema.sql` を廃止（migrations へ集約）
+- [x] 5. `vite-dev-persistence.ts` を `orderedMigrationStatements()` 利用＋migrations ディレクトリ読込に変更
+- [x] 6. `wrangler.toml` の `[[d1_databases]]` に `migrations_dir` を追加
+- [x] 7. `cloudflare-pages.yml` に「Apply D1 migrations (remote)」ステップを deploy 前に追加
+- [x] 8. `d1-migrate.yml`（PR の `--local` 検証）を新規作成
+- [x] 9. `infra/d1/README.md`（マイグレーション追加手順）を作成
+- [x] 10. `npx tsc -b` と `npm test` が緑であることを確認
+- [ ] 11. PR 作成 → セルフレビュー（正確性・可読性・性能・セキュリティ・保守性）→ 指摘修正
+- [ ] 12. （マージ後）本番で migrations 自動適用とアプリ動作を確認

--- a/infra/d1/README.md
+++ b/infra/d1/README.md
@@ -1,0 +1,37 @@
+# D1 スキーマ運用（マイグレーション）
+
+LibCheck の Cloudflare D1（`registered_libraries` / `search_history`、#74）のスキーマは
+`infra/d1/migrations/` 配下の**連番マイグレーション**で管理する（#83）。
+
+## 仕組み
+
+- マイグレーションファイル: `infra/d1/migrations/NNNN_説明.sql`（例: `0001_init.sql`）
+- 正本は `wrangler d1 migrations`。適用済みは D1 内の `d1_migrations` 表で追跡される。
+- `wrangler.toml` の `[[d1_databases]]` に `migrations_dir = "infra/d1/migrations"` を設定済み。
+
+### 適用の経路
+
+| タイミング | 何が起きるか | どこ |
+| --- | --- | --- |
+| PR（`infra/d1/migrations/**` 変更） | `d1 migrations apply libcheck --local`（一時 SQLite に適用＝SQL 検証。本番に触れない） | `.github/workflows/d1-migrate.yml` |
+| main マージ / 手動 | `d1 migrations apply libcheck --remote` を**デプロイ前**に実行（未適用のみ・冪等） | `.github/workflows/cloudflare-pages.yml` |
+| ローカル `npm run dev` | `infra/d1/migrations/` を連番順に `.dev.d1.sqlite` へ適用 | `vite-dev-persistence.ts` → `vite-dev-migrations.ts` |
+
+本番適用はデプロイと同一ジョブの前段ステップに置き、「スキーマ→コード」の順序を保証する。
+
+## 新しいマイグレーションの追加手順
+
+1. 直前の番号 + 1 でファイルを作る: `infra/d1/migrations/0002_説明.sql`
+2. SQL を書く。可能なら冪等（`IF NOT EXISTS` / `ADD COLUMN` 等）にする。
+   - ⚠️ D1(SQLite) の `ALTER TABLE` は機能が限られる（列の削除・型変更は不可）。
+     非互換変更は「新テーブル作成 → データ移送 → 旧テーブル削除」の手順を分割して書く。
+3. ローカル確認: `npm run dev` を起動し、対象機能（登録図書館・検索履歴）が動くこと。
+4. PR を出すと CI（`d1-migrate.yml`）が `--local` 適用で SQL を検証する。
+5. main にマージすると本番 D1 へ自動適用され、続けてアプリがデプロイされる。
+
+## ベースライン（0001）の注意
+
+`0001_init.sql` は #74 で手動適用済みの本番 D1 に対する**ベースライン**。本番には
+`d1_migrations` 表が無い状態で初回 `--remote` 適用が走るため `0001` が実行されるが、
+`CREATE TABLE IF NOT EXISTS` により実テーブルは no-op で、wrangler が `0001` を
+適用済みとして記録する。以降は通常どおり差分（`0002` 以降）だけが適用される。

--- a/infra/d1/migrations/0001_init.sql
+++ b/infra/d1/migrations/0001_init.sql
@@ -1,5 +1,6 @@
--- Cloudflare D1 スキーマ（#74 永続化）
--- 適用: wrangler d1 execute libcheck --remote --file infra/d1/schema.sql
+-- 0001 ベースライン: #74 の永続化スキーマ（登録図書館・検索履歴）。
+-- 既存の本番 D1 は migrations 導入前に手動適用済みのため、IF NOT EXISTS で
+-- 冪等にし、初回 `wrangler d1 migrations apply` でも no-op で安全に通す。
 
 CREATE TABLE IF NOT EXISTS registered_libraries (
   user_id      TEXT    NOT NULL,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -19,5 +19,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts", "vite-dev-persistence.ts"]
+  "include": ["vite.config.ts", "vite-dev-persistence.ts", "vite-dev-migrations.ts"]
 }

--- a/vite-dev-migrations.test.ts
+++ b/vite-dev-migrations.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+import { orderedMigrationStatements } from "./vite-dev-migrations";
+
+describe("orderedMigrationStatements", () => {
+  it("単一ファイルの複数文を順序どおり返す", () => {
+    const stmts = orderedMigrationStatements([
+      {
+        name: "0001_init.sql",
+        content: "CREATE TABLE a (id TEXT);\nCREATE TABLE b (id TEXT);",
+      },
+    ]);
+    expect(stmts).toEqual(["CREATE TABLE a (id TEXT)", "CREATE TABLE b (id TEXT)"]);
+  });
+
+  it("-- 行コメントを除去する", () => {
+    const stmts = orderedMigrationStatements([
+      {
+        name: "0001_init.sql",
+        content: "-- これはコメント\nCREATE TABLE a (id TEXT);\n  -- 字下げコメント\n",
+      },
+    ]);
+    expect(stmts).toEqual(["CREATE TABLE a (id TEXT)"]);
+  });
+
+  it("ファイル名の数値プレフィックス昇順で連結する（入力順に依らない）", () => {
+    const stmts = orderedMigrationStatements([
+      { name: "0002_add.sql", content: "ALTER TABLE a ADD COLUMN x TEXT;" },
+      { name: "0001_init.sql", content: "CREATE TABLE a (id TEXT);" },
+      { name: "0010_late.sql", content: "CREATE TABLE z (id TEXT);" },
+    ]);
+    expect(stmts).toEqual([
+      "CREATE TABLE a (id TEXT)",
+      "ALTER TABLE a ADD COLUMN x TEXT",
+      "CREATE TABLE z (id TEXT)",
+    ]);
+  });
+
+  it(".sql 以外のファイルは無視する", () => {
+    const stmts = orderedMigrationStatements([
+      { name: "0001_init.sql", content: "CREATE TABLE a (id TEXT);" },
+      { name: "README.md", content: "not sql; should be ignored;" },
+      { name: ".DS_Store", content: "bink" },
+    ]);
+    expect(stmts).toEqual(["CREATE TABLE a (id TEXT)"]);
+  });
+
+  it("空文・空白のみの断片は捨てる", () => {
+    const stmts = orderedMigrationStatements([
+      { name: "0001_init.sql", content: "CREATE TABLE a (id TEXT);;\n\n  ;\n" },
+    ]);
+    expect(stmts).toEqual(["CREATE TABLE a (id TEXT)"]);
+  });
+});

--- a/vite-dev-migrations.ts
+++ b/vite-dev-migrations.ts
@@ -1,0 +1,38 @@
+/**
+ * dev サーバ / テスト用: D1 マイグレーションファイル群から、実行すべき SQL 文を
+ * 連番順に取り出す純粋関数。本番は `wrangler d1 migrations apply` が同じ
+ * `infra/d1/migrations/` を適用する（CI）。ローカルはこの結果を node:sqlite に流す。
+ *
+ * - `.sql` のファイルのみ対象
+ * - ファイル名の先頭の数値プレフィックス昇順（同値はファイル名で安定整列）
+ * - `--` で始まる行コメントを除去
+ * - `;` で文分割し、空白のみの断片は捨てる（末尾の `;` は含めない）
+ */
+export function orderedMigrationStatements(
+  files: { name: string; content: string }[],
+): string[] {
+  const numericPrefix = (name: string): number => {
+    const m = /^(\d+)/.exec(name);
+    return m ? Number(m[1]) : Number.POSITIVE_INFINITY;
+  };
+
+  const sorted = files
+    .filter((f) => f.name.toLowerCase().endsWith(".sql"))
+    .sort((a, b) => {
+      const d = numericPrefix(a.name) - numericPrefix(b.name);
+      return d !== 0 ? d : a.name.localeCompare(b.name);
+    });
+
+  const statements: string[] = [];
+  for (const file of sorted) {
+    const stripped = file.content
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("--"))
+      .join("\n");
+    for (const part of stripped.split(";")) {
+      const stmt = part.trim();
+      if (stmt) statements.push(stmt);
+    }
+  }
+  return statements;
+}

--- a/vite-dev-persistence.ts
+++ b/vite-dev-persistence.ts
@@ -1,6 +1,8 @@
 import type { Plugin } from "vite";
 import type { IncomingMessage, ServerResponse } from "node:http";
 
+import { orderedMigrationStatements } from "./vite-dev-migrations";
+
 /**
  * dev サーバ専用: 本番と同じ Pages Functions（登録図書館・検索履歴）を、
  * ローカル SQLite（node:sqlite）を D1 互換アダプタで包んで実行する。
@@ -114,16 +116,17 @@ export function devPersistencePlugin(): Plugin {
       const root = process.cwd();
       const db = new DatabaseSyncCtor(path.resolve(root, ".dev.d1.sqlite"));
 
-      // スキーマ適用（CREATE IF NOT EXISTS で冪等）。
-      const schema = fs.readFileSync(
-        path.resolve(root, "infra/d1/schema.sql"),
-        "utf8",
-      );
-      const stripped = schema
-        .split("\n")
-        .filter((l) => !l.trim().startsWith("--"))
-        .join("\n");
-      for (const stmt of stripped.split(";").map((s) => s.trim()).filter(Boolean)) {
+      // マイグレーション適用（本番は wrangler d1 migrations apply が同じ
+      // infra/d1/migrations/ を適用する）。ローカルは連番順に流して
+      // .dev.d1.sqlite を構築する。各文は IF NOT EXISTS 等で冪等。
+      const migrationsDir = path.resolve(root, "infra/d1/migrations");
+      const migrationFiles = fs
+        .readdirSync(migrationsDir)
+        .map((name) => ({
+          name,
+          content: fs.readFileSync(path.resolve(migrationsDir, name), "utf8"),
+        }));
+      for (const stmt of orderedMigrationStatements(migrationFiles)) {
         db.exec(stmt + ";");
       }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,3 +17,6 @@ pages_build_output_dir = "dist"
 binding = "DB"
 database_name = "libcheck"
 database_id = "ba647dce-2a7a-4e0e-88f9-349dce14ce51"
+# スキーマは infra/d1/migrations/ の連番マイグレーションで管理する（#83）。
+# CI（cloudflare-pages.yml）が main 反映時に `d1 migrations apply --remote` を回す。
+migrations_dir = "infra/d1/migrations"


### PR DESCRIPTION
Closes #83

## 概要

#74 の D1 永続化スキーマを、手動 `schema.sql` 適用から **`wrangler d1 migrations` 運用**へ移行する。スキーマ変更を追跡・再現・CI 自動適用できるようにする。

## 変更点

- **マイグレーション化**: `infra/d1/schema.sql` → `infra/d1/migrations/0001_init.sql`（ベースライン）。既存本番 D1 に冪等適用できるよう `IF NOT EXISTS` 維持。
- **wrangler.toml**: `[[d1_databases]]` に `migrations_dir = "infra/d1/migrations"`。
- **本番適用（cloudflare-pages.yml）**: デプロイ**前**に `d1 migrations apply --remote`。スキーマ→コードの順序を保証し、適用失敗時は deploy しない。冪等（適用済みは `d1_migrations` 表でスキップ）。
- **PR 検証（d1-migrate.yml）**: `d1 migrations apply --local` で SQL の妥当性のみ確認（本番に触れない）。
- **ローカル（vite-dev-persistence.ts）**: `schema.sql` 単発読みから migrations 順次適用へ。順序・コメント除去・文分割を純粋関数 `orderedMigrationStatements()`（`vite-dev-migrations.ts`）に切り出し、ユニットテスト追加。
- **ドキュメント**: `infra/d1/README.md` に追加手順とベースラインの注意。

## 設計判断

- 本番適用を別ワークフローにせず deploy ジョブの前段ステップに同居 → push 時の並走による順序崩れを回避。
- CI はローカル `wrangler` 導入（過去に sharp ビルドで失敗）に依存せず `cloudflare/wrangler-action@v3` を使用。既存 Secrets を流用（新規シークレットなし）。

## Test Plan

- [x] `npx tsc -b` 緑
- [x] `npm test` 緑（288、`orderedMigrationStatements` の5ケース追加）
- [x] dev 適用パスを node:sqlite で検証（2文→`registered_libraries`/`search_history` 作成、再適用も冪等）
- [ ] （マージ後）main の deploy ワークフローで `d1 migrations apply --remote` が成功し、`/api/me`・登録図書館・検索履歴が従来どおり動くこと
- [x] （PR）`d1-migrate.yml` の `--local` 検証ジョブが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
