### PR TITLE
Calil プロキシの認証必須化 + library キャッシュ（#89 / M-1 暫定）

### DIFF
--- a/docs/89-calil-proxy-auth-cache/design.md
+++ b/docs/89-calil-proxy-auth-cache/design.md
@@ -1,0 +1,122 @@
+# #89 Calil プロキシ 認証必須化 + library キャッシュ — Design
+
+## Architecture Overview
+
+```mermaid
+flowchart TD
+  C[ブラウザ CalilApiClient] -->|Authorization: Bearer <idToken>| P[/api/calil/:action/]
+  P --> A{requireUser}
+  A -- 無効 --> E401[401]
+  A -- 有効 --> K{action==library かつ cache hit?}
+  K -- hit --> R1[キャッシュ応答]
+  K -- miss/その他 --> U[カーリル上流に appkey 注入して中継]
+  U --> S{action==library?}
+  S -- yes --> R2[Cache-Control public + Cache API put]
+  S -- no(check) --> R3[no-store]
+```
+
+要点:
+- **認証はキャッシュ参照より前**。匿名・偽トークンは 401 で即終了し、上流にもキャッシュにも触れない（厳密な C）。
+- `library` のみキャッシュ（準静的）。`check`（リアルタイム在庫）は `no-store`。
+- Cache API はランタイム機能。テスト（`caches` 不在）では未使用パスとして安全にスキップ。
+
+## Component Design
+
+### サーバ `functions/api/calil/[action].js`
+
+```js
+import { requireUser } from '../_shared/googleAuth.js';
+
+const CALIL_ORIGIN = 'https://api.calil.jp';
+const ALLOWED_ACTIONS = new Set(['library', 'check']);
+const LIBRARY_CACHE_TTL = 86400; // 1日
+
+export async function onRequestGet(context) {
+  const { request, env, params } = context;
+  const action = params.action;
+  if (!ALLOWED_ACTIONS.has(action)) return new Response('Not Found', { status: 404 });
+
+  // C: 認証必須（上流＝キー使用の前段で弾く）
+  const { user, response: authResponse } = await requireUser(request, env);
+  if (!user) return authResponse;
+
+  const appKey = env.CALIL_APP_KEY;
+  if (!appKey) return new Response('Server misconfigured: CALIL_APP_KEY is not set', { status: 500 });
+
+  const requestUrl = new URL(request.url);
+  const cacheable = action === 'library';
+  const cache = cacheable ? globalThis.caches?.default : undefined;
+
+  // library はキャッシュ参照
+  let cacheKey;
+  if (cache) {
+    const keyUrl = new URL(requestUrl.toString());
+    keyUrl.searchParams.delete('appkey'); // クライアントは空 appkey を送る
+    cacheKey = new Request(keyUrl.toString(), { method: 'GET' });
+    const hit = await cache.match(cacheKey);
+    if (hit) return hit;
+  }
+
+  // 上流へ appkey を注入して中継
+  const target = new URL(`${CALIL_ORIGIN}/${action}`);
+  for (const [k, v] of requestUrl.searchParams) target.searchParams.set(k, v);
+  target.searchParams.set('appkey', appKey);
+
+  let upstream;
+  try {
+    upstream = await fetch(target.toString(), { headers: { accept: 'application/json' } });
+  } catch {
+    return new Response('Bad Gateway', { status: 502 });
+  }
+
+  const bodyText = await upstream.text();
+  const result = new Response(bodyText, {
+    status: upstream.status,
+    headers: {
+      'content-type': upstream.headers.get('content-type') ?? 'application/json',
+      'cache-control':
+        cacheable && upstream.status === 200
+          ? `public, max-age=${LIBRARY_CACHE_TTL}`
+          : 'no-store',
+    },
+  });
+
+  if (cache && upstream.status === 200) {
+    context.waitUntil?.(cache.put(cacheKey, result.clone()));
+  }
+  return result;
+}
+```
+
+### クライアント `CalilApiClient`
+
+`getAuthToken()` を既定の `tokenProvider` として注入し、`executeRequest` で Bearer を付与:
+
+```js
+this.tokenProvider = options.tokenProvider ?? getAuthToken;
+...
+private authHeaders() {
+  const token = this.tokenProvider();
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+// executeRequest:
+response = await this.fetchFn(url, { signal: controller.signal, headers: this.authHeaders() });
+```
+
+- 既存テストは `tokenProvider` 未指定＝既定 `getAuthToken`、テスト環境ではトークン未設定 → ヘッダ無し → **無改変で緑**。
+- 新規テストで `tokenProvider: () => 'tok'` を渡し、fetch の第2引数に `authorization: 'Bearer tok'` が入ることを検証。
+
+### `calilApiConfig.ts` のコメント更新
+
+Azure Functions 前提の SECURITY コメントを、Cloudflare Pages Functions + 認証必須の現状に更新（挙動変更なし）。
+
+## Data Flow
+
+1. クライアントが ID トークン付きで `/api/calil/{action}` を呼ぶ。
+2. Function が `requireUser`（401 で遮断）。
+3. `library` はキャッシュ参照（hit ならキー消費せず返す）。
+4. miss/`check` は上流へ appkey を注入して中継。`library` は `public` キャッシュ、`check` は `no-store`。
+
+## Domain Models
+
+変更なし。レスポンス形・`LibraryResponse`/`CheckResponse` は不変。本 issue は配信前段（認証・キャッシュ・ヘッダ）のみ。

--- a/docs/89-calil-proxy-auth-cache/requirements.md
+++ b/docs/89-calil-proxy-auth-cache/requirements.md
@@ -1,0 +1,47 @@
+# #89 Calil プロキシ 認証必須化 + library キャッシュ — Requirements
+
+## Problem Statement
+
+`functions/api/calil/[action].js`（カーリル API プロキシ）は認証を要求せず、リクエストごとにサーバの `CALIL_APP_KEY` を注入して中継する。そのためインターネット上の誰でも、あなたのキーでカーリル API を叩ける（M-1）。キー自体は漏れないが、クォータ濫用・キー停止・無駄なコストの温床になる。
+
+Cloudflare の Rate Limiting(A) は有料のため、低コストな組合せで残リスクを下げる:
+- **C**: プロキシに認証を必須化し、匿名・偽トークンを上流到達前に弾く。
+- **library キャッシュ**: 準静的な `library` 応答をキャッシュし、上流呼び出し（クォータ消費）を削減。
+
+## Requirements
+
+### Functional
+
+- FR-1: `/api/calil/*` はトークン無し／無効トークンで **401** を返し、上流（カーリル）へ中継しない。
+- FR-2: 有効な Google ID トークン（`AUTH_MOCK` 時はモックトークン）で従来どおり `library`/`check` を中継する。
+- FR-3: クライアント（`CalilApiClient`）はログイン中の ID トークンを `Authorization: Bearer` で送る。未ログイン時はヘッダを付けない。
+- FR-4: `library` 応答は `Cache-Control: public, max-age=...` を付け、Cloudflare Cache API でエッジキャッシュする（同一地域の再検索で上流を呼ばない）。
+- FR-5: `check` 応答は従来どおり `no-store`（キャッシュしない）。
+- FR-6: 認証はキャッシュ参照より前に行う（キャッシュヒットも認証必須）。
+
+### Non-Functional
+
+- NFR-1: 既存の `CalilApiClient` ユニットテスト（トークン未設定）は無改変で緑のまま。
+- NFR-2: ローカル dev（`/api/calil` は Vite proxy 経由で Function を通らない）は従来どおり動く。
+- NFR-3: Cache API はテスト環境（`caches` 不在）でも安全にスキップされる。
+
+## Constraints
+
+- 新規シークレット・有料機能を増やさない（既存の認証基盤と Cache API のみ）。
+- データ隔離・`CALIL_APP_KEY` のサーバ専用性は不変。
+
+## Acceptance Criteria
+
+- AC-1: 本番 `/api/calil/library`・`/api/calil/check` がトークン無しで 401。
+- AC-2: 有効トークンで 200・従来のレスポンス。`library` に `Cache-Control: public`、`check` に `no-store`。
+- AC-3: `CalilApiClient` はトークンがあるとき Bearer を送る（テストで検証）。
+- AC-4: 既存テスト + 新規テストが緑、`npx tsc -b` 緑。
+
+## User Stories
+
+- 運用者として、自分のカーリルキーが見知らぬ第三者に使い回されない状態にしたい。
+- 利用者として、同じ地域の図書館一覧の再取得が速く、無駄な API 消費が起きないようにしたい。
+
+## Out of Scope（将来）
+
+- per-user / per-IP レート制限（KV/D1）、ログイン許可リスト、ID トークン失効時(〜1h)の検索 401 に対する自動再取得。

--- a/docs/89-calil-proxy-auth-cache/tasks.md
+++ b/docs/89-calil-proxy-auth-cache/tasks.md
@@ -1,0 +1,12 @@
+# #89 Calil プロキシ 認証必須化 + library キャッシュ — Tasks
+
+TDD で進める。
+
+- [x] 1. プロキシ Function の失敗するテストを書く（401 / 404 / library=public / check=no-store / appkey 注入）
+- [x] 2. `functions/api/calil/[action].js` に requireUser + キャッシュ + ヘッダを実装しテストを緑にする
+- [x] 3. `CalilApiClient` の失敗するテストを書く（tokenProvider あり → Bearer 送出 / なし → 無ヘッダ）
+- [x] 4. `CalilApiClient` に tokenProvider + authHeaders を実装
+- [x] 5. `calilApiConfig.ts` のコメントを Cloudflare/認証前提に更新
+- [x] 6. `npx tsc -b` / `npm test` 緑
+- [ ] 7. PR 作成 → セルフレビュー → 指摘修正
+- [ ] 8. （デプロイ後）本番で 401（無トークン）・ログイン後の検索・library の Cache-Control を確認

--- a/functions/api/calil/[action].js
+++ b/functions/api/calil/[action].js
@@ -3,17 +3,27 @@
  *
  * Routed at `/api/calil/{action}` (the `[action]` dynamic segment). It injects
  * the secret `appkey` server-side so the key is never shipped to the browser.
- * Port of the former Azure Functions `calilProxy.js` (same behavior).
+ *
+ * 濫用対策（#89, M-1）:
+ *  - 認証必須（requireUser）。匿名・偽トークンは 401 で弾き、上流（=キー使用）に
+ *    中継しない。これにより見知らぬ第三者があなたの appkey を使い回せない。
+ *  - `library`（地域の図書館一覧・準静的）はエッジキャッシュし、上流呼び出し
+ *    （クォータ消費）を削減。`check`（リアルタイム在庫）は no-store。
  *
  * The `CALIL_APP_KEY` secret is provided via:
  *   - production: Cloudflare Pages project → Settings → Variables and Secrets
- *   - local:      .dev.vars → CALIL_APP_KEY (for `wrangler pages dev`)
+ *   - local:      .dev.vars → CALIL_APP_KEY（ただしローカル /api/calil は Vite の
+ *                 dev proxy 経由で、この Function は通らない）
  */
+import { requireUser } from '../../_shared/googleAuth.js';
 
 const CALIL_ORIGIN = 'https://api.calil.jp';
 
 /** Only these upstream actions may be proxied. */
 const ALLOWED_ACTIONS = new Set(['library', 'check']);
+
+/** library（準静的）のエッジキャッシュ TTL（秒）。 */
+const LIBRARY_CACHE_TTL = 86400; // 1 日
 
 export async function onRequestGet(context) {
   const { request, env, params } = context;
@@ -23,6 +33,10 @@ export async function onRequestGet(context) {
     return new Response('Not Found', { status: 404 });
   }
 
+  // 認証必須: 上流（=appkey 使用）に到達する前に弾く。
+  const { user, response: authResponse } = await requireUser(request, env);
+  if (!user) return authResponse;
+
   const appKey = env.CALIL_APP_KEY;
   if (!appKey) {
     return new Response('Server misconfigured: CALIL_APP_KEY is not set', {
@@ -31,6 +45,21 @@ export async function onRequestGet(context) {
   }
 
   const requestUrl = new URL(request.url);
+
+  // library のみキャッシュ対象。Cache API はランタイム機能（テスト等で不在なら
+  // undefined となりキャッシュ経路はスキップされる）。
+  const cacheable = action === 'library';
+  const cache = cacheable ? globalThis.caches?.default : undefined;
+  let cacheKey;
+  if (cache) {
+    // クライアントは空 appkey を送る。揺れを避けるため appkey を除いた正規 URL を鍵に。
+    const keyUrl = new URL(requestUrl.toString());
+    keyUrl.searchParams.delete('appkey');
+    cacheKey = new Request(keyUrl.toString(), { method: 'GET' });
+    const hit = await cache.match(cacheKey);
+    if (hit) return hit;
+  }
+
   const target = new URL(`${CALIL_ORIGIN}/${action}`);
   // Forward the client's query params...
   for (const [key, value] of requestUrl.searchParams) {
@@ -51,13 +80,22 @@ export async function onRequestGet(context) {
   }
 
   const bodyText = await upstream.text();
-  return new Response(bodyText, {
+  const result = new Response(bodyText, {
     status: upstream.status,
     headers: {
       'content-type':
         upstream.headers.get('content-type') ?? 'application/json',
-      // Responses depend on a secret-bearing upstream request; do not cache.
-      'cache-control': 'no-store',
+      // library 成功時のみキャッシュ可。それ以外（check・エラー）は秘密注入の
+      // 上流に依存するためキャッシュしない。
+      'cache-control':
+        cacheable && upstream.status === 200
+          ? `public, max-age=${LIBRARY_CACHE_TTL}`
+          : 'no-store',
     },
   });
+
+  if (cache && upstream.status === 200) {
+    context.waitUntil?.(cache.put(cacheKey, result.clone()));
+  }
+  return result;
 }

--- a/functions/api/calil/proxy.test.ts
+++ b/functions/api/calil/proxy.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { onRequestGet } from './[action].js';
+import { MOCK_ID_TOKEN } from '../../_shared/googleAuth.js';
+
+const AUTH = { authorization: `Bearer ${MOCK_ID_TOKEN}` };
+const ENV = { AUTH_MOCK: '1', CALIL_APP_KEY: 'server-secret-key' };
+
+function ctx(action, headers, env = ENV, query = '?pref=%E6%9D%B1%E4%BA%AC%E9%83%BD&appkey=') {
+  return {
+    request: new Request(`https://x/api/calil/${action}${query}`, {
+      method: 'GET',
+      headers,
+    }),
+    env,
+    params: { action },
+  };
+}
+
+function mockFetch(impl) {
+  const fn = vi.fn(impl);
+  globalThis.fetch = fn;
+  return fn;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('calil proxy: 認証', () => {
+  it('トークン無しは 401 で上流を呼ばない', async () => {
+    const fetchFn = mockFetch(async () => new Response('[]', { status: 200 }));
+    const res = await onRequestGet(ctx('library', {}));
+    expect(res.status).toBe(401);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('許可外 action は 404', async () => {
+    const res = await onRequestGet(ctx('hack', AUTH));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('calil proxy: 中継とヘッダ', () => {
+  it('library: appkey をサーバ値で注入し、Cache-Control: public を付ける', async () => {
+    const fetchFn = mockFetch(async (url) => {
+      const u = new URL(String(url));
+      expect(u.pathname).toBe('/library');
+      expect(u.searchParams.get('appkey')).toBe('server-secret-key');
+      return new Response('[]', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    const res = await onRequestGet(ctx('library', AUTH));
+    expect(res.status).toBe(200);
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(res.headers.get('cache-control')).toMatch(/public/);
+  });
+
+  it('check: no-store（キャッシュしない）', async () => {
+    mockFetch(async () => new Response('{}', { status: 200 }));
+    const res = await onRequestGet(
+      ctx('check', AUTH, ENV, '?isbn=9784&systemid=Tokyo_Minato&appkey='),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('CALIL_APP_KEY 未設定は 500', async () => {
+    mockFetch(async () => new Response('[]', { status: 200 }));
+    const res = await onRequestGet(ctx('library', AUTH, { AUTH_MOCK: '1' }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/data/datasources/calilApiClient.test.ts
+++ b/src/data/datasources/calilApiClient.test.ts
@@ -300,3 +300,49 @@ describe('CalilApiClient.searchLibraries', () => {
     ).rejects.toBeInstanceOf(CalilHttpException);
   });
 });
+
+describe('CalilApiClient auth header (#89)', () => {
+  function captureInitFetch(): {
+    fetchFn: typeof fetch;
+    last: () => RequestInit | undefined;
+  } {
+    let captured: RequestInit | undefined;
+    const fetchFn = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        captured = init;
+        return new Response('[]', { status: 200 });
+      },
+    ) as unknown as typeof fetch;
+    return { fetchFn, last: () => captured };
+  }
+
+  test('tokenProvider がトークンを返すと Authorization: Bearer を送る', async () => {
+    const { fetchFn, last } = captureInitFetch();
+    const client = new CalilApiClient({
+      appKey: '',
+      fetchFn,
+      baseUrl: '',
+      tokenProvider: () => 'tok123',
+    });
+
+    await client.searchLibraries({ pref: '東京都' });
+
+    const headers = last()?.headers as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer tok123');
+  });
+
+  test('トークンが無ければ Authorization を付けない', async () => {
+    const { fetchFn, last } = captureInitFetch();
+    const client = new CalilApiClient({
+      appKey: '',
+      fetchFn,
+      baseUrl: '',
+      tokenProvider: () => null,
+    });
+
+    await client.searchLibraries({ pref: '東京都' });
+
+    const headers = (last()?.headers ?? {}) as Record<string, string>;
+    expect(headers.authorization).toBeUndefined();
+  });
+});

--- a/src/data/datasources/calilApiClient.ts
+++ b/src/data/datasources/calilApiClient.ts
@@ -14,6 +14,7 @@ import {
   libraryResponseFromJson,
 } from '@/data/models/libraryResponse';
 import { CALIL_API_CONFIG } from '@/data/datasources/calilApiConfig';
+import { getAuthToken } from '@/data/datasources/authTokenStore';
 
 /** Sleep helper used between polling requests. */
 function delay(ms: number): Promise<void> {
@@ -28,6 +29,12 @@ export interface CalilApiClientOptions {
   pollingIntervalMs?: number;
   maxPollingCount?: number;
   httpTimeoutMs?: number;
+  /**
+   * 現在の ID トークンを返す関数（既定: AuthTokenStore の getAuthToken）。
+   * 本番のプロキシ（/api/calil）は認証必須（#89）のため Bearer を付ける。
+   * 未ログイン時は null を返し、ヘッダは付与しない。
+   */
+  tokenProvider?: () => string | null;
 }
 
 export class CalilApiClient {
@@ -37,11 +44,13 @@ export class CalilApiClient {
   private readonly pollingIntervalMs: number;
   private readonly maxPollingCount: number;
   private readonly httpTimeoutMs: number;
+  private readonly tokenProvider: () => string | null;
 
   constructor(options: CalilApiClientOptions) {
     this.appKey = options.appKey;
     this.fetchFn =
       options.fetchFn ?? globalThis.fetch.bind(globalThis);
+    this.tokenProvider = options.tokenProvider ?? getAuthToken;
     this.baseUrl = options.baseUrl ?? CALIL_API_CONFIG.baseUrl;
     this.pollingIntervalMs =
       options.pollingIntervalMs ?? CALIL_API_CONFIG.pollingIntervalMs;
@@ -147,6 +156,12 @@ export class CalilApiClient {
     return this.isAbsoluteBase() ? this.baseUrl : 'http://localhost';
   }
 
+  /** 認証必須プロキシ用の Authorization ヘッダ（未ログイン時は空）。 */
+  private authHeaders(): Record<string, string> {
+    const token = this.tokenProvider();
+    return token ? { authorization: `Bearer ${token}` } : {};
+  }
+
   private async executeRequest(url: string): Promise<string> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => {
@@ -155,7 +170,10 @@ export class CalilApiClient {
 
     let response: Response;
     try {
-      response = await this.fetchFn(url, { signal: controller.signal });
+      response = await this.fetchFn(url, {
+        signal: controller.signal,
+        headers: this.authHeaders(),
+      });
     } catch (e) {
       if (e instanceof CalilApiException) {
         throw e;

--- a/src/data/datasources/calilApiConfig.ts
+++ b/src/data/datasources/calilApiConfig.ts
@@ -6,12 +6,14 @@
  * If the key were embedded here (e.g. via a `VITE_`-prefixed env var) Vite would
  * inline it into the production bundle and leak it to every user. Instead the key
  * is injected **server-side**:
- *   - production: the Azure Functions proxy (`api/src/functions/calilProxy.js`)
- *     overrides `appkey` from the `CALIL_APP_KEY` application setting when serving
- *     `/api/calil/*` behind Azure Static Web Apps.
+ *   - production: the Cloudflare Pages Function (`functions/api/calil/[action].js`)
+ *     overrides `appkey` from the `CALIL_APP_KEY` secret. The proxy also requires a
+ *     valid Google ID token (Authorization: Bearer) so the key cannot be used by
+ *     anonymous third parties (#89).
  *   - local dev: the Vite dev proxy (`vite.config.ts`) injects `appkey` from the
- *     non-`VITE_` `CALIL_APP_KEY` env var.
- * The client therefore sends an empty `appkey`, which the proxy replaces.
+ *     non-`VITE_` `CALIL_APP_KEY` env var (does not go through the Function).
+ * The client therefore sends an empty `appkey`, which the proxy replaces, plus the
+ * current ID token as a Bearer header (see CalilApiClient).
  *
  * All requests go through the same-origin `/api/calil` path in every environment.
  */


### PR DESCRIPTION
Closes #89

## 概要

セキュリティレビュー **M-1**（`/api/calil/*` が無認証であなたの `CALIL_APP_KEY` で叩ける）への対応。Cloudflare の有料 Rate Limiting(A) を使わず、**C（認証必須）+ library キャッシュ**で残リスクを下げる。

## 変更点

### C: プロキシ認証必須
- `functions/api/calil/[action].js` に `requireUser` を追加。トークン無し/無効は **401** で、上流（=キー使用）に中継しない。`/api/me` 等と同じ検証基盤。
- `CalilApiClient` がログイン中の ID トークンを `Authorization: Bearer` で送る（`tokenProvider` 注入可・未ログイン時は付けない）。`getAuthToken` を既定にし、protected リポジトリと同じ経路。

### library キャッシュ
- `library`（地域の図書館一覧・準静的）は Cloudflare Cache API でエッジキャッシュ、`Cache-Control: public, max-age=86400`。`check`（在庫）は `no-store`。
- **認証はキャッシュ参照より前**（ヒットも認証必須＝厳密な C）。`caches` 不在のテスト環境ではキャッシュ経路を安全にスキップ。

### その他
- `calilApiConfig.ts` の SECURITY コメントを Cloudflare/認証前提に更新。

## 残リスク（docs に明記・将来対応）
- ログイン開放のため「ログインした誰か」による濫用・トークン再生（〜1h）は残る → 将来 KV/D1 で per-user 制限、ログイン許可リスト。
- DoS は「キー濫用」→「Functions 呼び出し枠」へ移る（A の領域）。
- ID トークン失効中の検索 401 → 自動再取得は follow-up。

## Test Plan
- [x] プロキシ Function: 無トークン 401（上流呼ばない）/ 404 / library=public / check=no-store / appkey 注入（5 ケース）
- [x] `CalilApiClient`: トークンありで Bearer 送出 / なしで無ヘッダ
- [x] 既存 Calil クライアントテスト無改変で緑
- [x] `npx tsc -b` / `npm test` 緑（316）
- [ ] （デプロイ後）本番 `/api/calil/library` がトークン無しで **401**、ログイン後の検索が従来どおり動作、library 応答に `Cache-Control: public`

> ⚠️ 認証必須化は機能変更です。クライアントのトークン送出は #74 の protected リポジトリと同じ `getAuthToken` 経路（本番実績あり）に依拠。マージ後に本番で 401 とログイン後検索を確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)