### PR TITLE
HttpOnly Cookie セッション: リロード時の再認証を解消（#91）

### DIFF
--- a/docs/91-cookie-session/design.md
+++ b/docs/91-cookie-session/design.md
@@ -1,0 +1,85 @@
+# #91 HttpOnly Cookie セッション — Design
+
+## Architecture Overview
+
+```mermaid
+sequenceDiagram
+  participant B as ブラウザ(SPA)
+  participant S as /api/session
+  participant M as /api/me
+  participant G as Google JWKS
+
+  Note over B: ログイン
+  B->>S: POST {idToken}
+  S->>G: jwtVerify(idToken, aud=GOOGLE_CLIENT_ID)
+  S-->>B: 200 user + Set-Cookie: session=<署名JWT> (HttpOnly/Secure/SameSite=Strict)
+
+  Note over B: リロード
+  B->>M: GET /api/me (Cookie 自動送信)
+  M-->>B: 200 user  (Cookie からセッション復元)
+
+  Note over B: ログアウト
+  B->>S: DELETE /api/session
+  S-->>B: 200 + Set-Cookie: session=; Max-Age=0
+```
+
+## Component Design
+
+### サーバ `functions/_shared/googleAuth.js`（拡張）
+
+- `signSession(user, secret, maxAgeSec)`: HMAC(HS256) で `{sub,email,name,picture}` を署名（jose `SignJWT`、exp 付き）。
+- `verifySession(token, secret)`: 検証して user を返す（失敗で throw）。
+- Cookie ヘルパ: `sessionSetCookie(value, maxAgeSec)` → `session=...; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=...`、`sessionClearCookie()` → `Max-Age=0`、`readCookie(request, name)`。
+- `requireUser` を「**Cookie 優先**、無ければ既存 Bearer（モック/Google）」に拡張:
+  1. `session` Cookie があり `SESSION_SECRET` で検証できれば user。
+  2. dev モック: `AUTH_MOCK==='1'` かつ Cookie が `MOCK_SESSION` なら MOCK_USER。
+  3. 既存 Bearer 経路（後方互換・既存テスト維持）。
+  4. いずれも無ければ 401。`SESSION_SECRET` 未設定かつ Cookie 経路必要時は 500。
+
+> Bearer 経路を残すことで、persistence/me/calil の既存サーバテスト（Bearer モック）は無改変で緑のまま。Cookie は「リロードでも送られる durable な資格情報」として一級で受理する。
+
+### 新規 `functions/api/session.js`
+
+- `onRequestPost`: body `{ idToken }`（モック時は `MOCK_ID_TOKEN`）。
+  - モック: `AUTH_MOCK==='1'` && `idToken===MOCK_ID_TOKEN` → user=MOCK_USER・Cookie 値=MOCK_SESSION。
+  - 本番: `verifyGoogleIdToken(idToken, env.GOOGLE_CLIENT_ID)` → user・`signSession(user, env.SESSION_SECRET)`。
+  - `Set-Cookie` を付けて user を 200 で返す。検証失敗 401、設定不足 500。
+- `onRequestDelete`: `sessionClearCookie()` を付けて 200。
+
+### クライアント
+
+- 新規 `src/data/datasources/sessionApiClient.ts`:
+  - `restore()`: `GET /api/me`（same-origin・Cookie 自動）→ `User | null`（401/失敗は null）。
+  - `create(idToken)`: `POST /api/session {idToken}`。
+  - `destroy()`: `DELETE /api/session`。
+- `AuthProvider`（拡張・後方互換）:
+  - 新 prop `sessionApi`（既定: 実 HTTP 実装）。
+  - マウント時、`initialUser` が無ければ `sessionApi.restore()` で復元（成功で setUser）。
+  - `signIn(user, idToken)`: 状態を同期更新（従来どおり）＋ `sessionApi.create(idToken).catch(()=>{})`。
+  - `signOut()`: 状態クリア＋ `sessionApi.destroy().catch(()=>{})`。
+  - 失敗は握りつぶす（テスト/オフラインでも UI を壊さない）。
+- 保護クライアント/リポジトリを **Cookie 前提**に:
+  - `protectedRequest(fetchFn, url, method, token, body?, timeout)` の `token` を `string | null` に。`token` があるときのみ `Authorization: Bearer` を付け、常に same-origin（Cookie 同送）。
+  - `ServerRegisteredLibraryRepositoryImpl` / `ServerSearchHistoryRepositoryImpl`: 「トークン無し→例外」を撤廃し、`tokenProvider()`（null 可）を素通し。認証失敗は API の 401 として表面化。
+  - Calil クライアント（#89）は token が null のとき Bearer を付けないので Cookie で通る（変更不要）。
+
+### dev プラグイン `vite-dev-persistence.ts`
+
+- ルートに `/api/session`・`/api/me` を追加（registered-libraries / search-history と同様に function を実行）。
+- dev env に `SESSION_SECRET: 'dev-secret'` を追加（既存 `AUTH_MOCK:'1'`, `GOOGLE_CLIENT_ID:'dev'` と併せて）。
+- これによりローカルでも「mock ログイン → Cookie 発行 → リロードで /api/me 復元」が本番同等に動く。
+
+## Data Flow
+
+1. ログイン: GIS トークン → `POST /api/session` → Set-Cookie。`signIn` が状態も即更新。
+2. リロード: `AuthProvider` が `GET /api/me`（Cookie）→ user 復元。保護/Calil は Cookie で認証。
+3. ログアウト: `DELETE /api/session` → Cookie 削除 → 状態クリア。
+
+## セキュリティ
+
+- HttpOnly: JS から読めず XSS 窃取不可。Secure: HTTPS 限定。SameSite=Strict: クロスサイト送信なし＝CSRF 遮断（GIS は JS ログインでリダイレクト不要のため Strict で問題なし）。
+- セッション JWT は `SESSION_SECRET`（HS256）で署名。クライアントには出ない。
+
+## Domain Models
+
+`User` 等は不変。本 issue は認証の保持方式（Cookie セッション）の追加であり、ドメインに変更なし。

--- a/docs/91-cookie-session/requirements.md
+++ b/docs/91-cookie-session/requirements.md
@@ -1,0 +1,43 @@
+# #91 HttpOnly Cookie セッション — Requirements
+
+## Problem Statement
+
+ID トークンをメモリ（React state）のみで保持しているため、ブラウザをリロードするとログイン状態が失われ、毎回 Google 再認証を求められる。サーバ発行の HttpOnly Cookie セッションで「リロードしても維持」を実現する。HttpOnly によりトークンは JS から読めず（XSS 窃取不可）、SameSite=Strict で CSRF を防ぐ。
+
+## Requirements
+
+### Functional
+
+- FR-1: `POST /api/session` は GIS の ID トークンを検証（jose）し、署名済みセッション JWT を HttpOnly/Secure/SameSite=Strict Cookie で発行する。
+- FR-2: `DELETE /api/session` はセッション Cookie を削除する（ログアウト）。
+- FR-3: `requireUser` はセッション Cookie を受理する（後方互換のため既存 Bearer も受理）。
+- FR-4: `GET /api/me` は Cookie からユーザーを返す。
+- FR-5: クライアントはマウント時に `GET /api/me` でセッションを復元し、有効なら再認証なしでログイン状態にする。
+- FR-6: 保護 API / Calil 呼び出しは、リロード後（メモリにトークン無し）でも同一オリジン Cookie で認証される。
+- FR-7: ログイン時にセッション Cookie が作成され、ログアウトで削除される。
+
+### Non-Functional
+
+- NFR-1: 既存サーバテスト（Bearer モック）を壊さない（requireUser は Cookie と Bearer の両対応）。
+- NFR-2: ローカル dev でも同じフロー（`/api/session`・`/api/me`）が動くよう dev プラグインで実行する。
+- NFR-3: `SESSION_SECRET` はサーバ専用シークレット（クライアントに出ない）。
+
+## Constraints
+
+- セッション Cookie は HttpOnly・Secure・SameSite=Strict・Path=/。
+- 同一オリジン fetch（既定 credentials=same-origin）で Cookie が自動送信されることに依拠。
+- セッション有効期限はサーバ側で管理（既定 7 日）。失効後は再ログイン。
+
+## Acceptance Criteria
+
+- AC-1: ログイン後にリロードしても再認証なしでログイン状態が維持される。
+- AC-2: Cookie 無し/無効で保護 API は 401。
+- AC-3: ログアウトで Cookie が消え、保護 API が 401 になる。
+- AC-4: 既存テスト + 新規テスト緑、`npx tsc -b` 緑。
+
+## User Stories
+
+- 利用者として、一度ログインしたらリロードしても入り直さずに使い続けたい。
+
+## Out of Scope（将来）
+- リフレッシュトークン/スライディング有効期限、サーバ側セッション失効リスト、複数デバイスのセッション管理。

--- a/docs/91-cookie-session/tasks.md
+++ b/docs/91-cookie-session/tasks.md
@@ -1,0 +1,15 @@
+# #91 HttpOnly Cookie セッション — Tasks
+
+TDD で進める。
+
+- [x] 1. `googleAuth`（session sign/verify・cookie ヘルパ・requireUser cookie 対応）の失敗するテストを書く
+- [x] 2. `googleAuth.js` に signSession/verifySession/cookie ヘルパ + requireUser cookie 対応を実装
+- [x] 3. `functions/api/session.js`（POST/DELETE）の失敗するテストを書く
+- [x] 4. `functions/api/session.js` を実装
+- [x] 5. `protectedRequest` / api クライアント / serverRepo を token 任意（Cookie 前提）に変更し、関連テストを更新
+- [x] 6. `sessionApiClient.ts`（restore/create/destroy）を実装＋テスト
+- [x] 7. `AuthProvider` にマウント復元 + create/destroy を組み込み（注入可）＋テスト更新
+- [x] 8. `vite-dev-persistence.ts` に /api/session・/api/me ルートと SESSION_SECRET を追加
+- [x] 9. `npx tsc -b` / `npm test` 緑
+- [ ] 10. PR 作成 → セルフレビュー → 指摘修正
+- [ ] 11. （デプロイ後）本番でログイン→リロード維持、ログアウト→401、SESSION_SECRET 設定を確認

--- a/functions/_shared/googleAuth.js
+++ b/functions/_shared/googleAuth.js
@@ -1,13 +1,18 @@
 /**
- * 共有: Google ID トークン検証と認証必須ハンドラ用ヘルパ。
+ * 共有: Google ID トークン検証・セッション Cookie・認証必須ハンドラ用ヘルパ。
  * `_shared` 配下はルートにならない（Pages はルートにマップしない）。
  *
- * dev-only mock: `AUTH_MOCK === '1'`（ローカル .dev.vars のみ・本番未設定）の
- * とき `MOCK_ID_TOKEN` は `MOCK_USER` を返す。
+ * 認証は次の二段（#91）:
+ *   1. セッション Cookie（HttpOnly・durable・リロードでも送られる）= 主。
+ *   2. Authorization: Bearer（後方互換: dev モック / Google ID トークン）。
+ *
+ * dev-only mock: `AUTH_MOCK === '1'`（ローカルのみ・本番未設定）のとき、
+ * `MOCK_ID_TOKEN`（Bearer）/ `MOCK_SESSION`（Cookie）は `MOCK_USER` を返す。
  */
-import { jwtVerify, createRemoteJWKSet } from 'jose';
+import { jwtVerify, createRemoteJWKSet, SignJWT } from 'jose';
 
 export const MOCK_ID_TOKEN = 'mock.dev.token';
+export const MOCK_SESSION = 'mock.dev.session';
 export const MOCK_USER = {
   id: 'mock-user',
   email: 'dev@example.com',
@@ -16,6 +21,10 @@ export const MOCK_USER = {
 
 const GOOGLE_ISSUERS = ['https://accounts.google.com', 'accounts.google.com'];
 const GOOGLE_JWKS_URL = 'https://www.googleapis.com/oauth2/v3/certs';
+
+const SESSION_COOKIE = 'session';
+/** セッションの既定有効期限（秒）= 7 日。 */
+export const SESSION_MAX_AGE = 7 * 24 * 60 * 60;
 
 let cachedJwks;
 function defaultJwks() {
@@ -30,12 +39,60 @@ export async function verifyGoogleIdToken(token, clientId, opts = {}) {
     issuer: GOOGLE_ISSUERS,
     audience: clientId,
   });
+  return userFromPayload(payload);
+}
+
+function userFromPayload(payload) {
   return {
     id: String(payload.sub),
     email: typeof payload.email === 'string' ? payload.email : undefined,
     name: typeof payload.name === 'string' ? payload.name : undefined,
     picture: typeof payload.picture === 'string' ? payload.picture : undefined,
   };
+}
+
+/** セッション JWT を HS256 で署名する（`SESSION_SECRET` 鍵）。 */
+export async function signSession(user, secret, maxAgeSec = SESSION_MAX_AGE) {
+  const key = new TextEncoder().encode(secret);
+  const nowSec = Math.floor(Date.now() / 1000);
+  return new SignJWT({
+    email: user.email,
+    name: user.name,
+    picture: user.picture,
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setSubject(String(user.id))
+    .setIssuedAt(nowSec)
+    .setExpirationTime(nowSec + maxAgeSec)
+    .sign(key);
+}
+
+/** セッション JWT を検証して user を返す。無効/期限切れは throw。 */
+export async function verifySession(token, secret) {
+  const key = new TextEncoder().encode(secret);
+  const { payload } = await jwtVerify(token, key);
+  return userFromPayload(payload);
+}
+
+/** Set-Cookie 値（HttpOnly/Secure/SameSite=Strict）。 */
+export function sessionSetCookie(value, maxAgeSec = SESSION_MAX_AGE) {
+  return `${SESSION_COOKIE}=${value}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=${maxAgeSec}`;
+}
+
+/** セッション Cookie を消す Set-Cookie 値。 */
+export function sessionClearCookie() {
+  return `${SESSION_COOKIE}=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0`;
+}
+
+/** Cookie ヘッダから指定名の値を取り出す（無ければ null）。 */
+export function readCookie(request, name) {
+  const header = request.headers.get('cookie') || '';
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) return part.slice(eq + 1).trim();
+  }
+  return null;
 }
 
 export function bearerToken(request) {
@@ -52,15 +109,30 @@ export function json(body, status) {
 }
 
 /**
- * 認証必須エンドポイント用。Bearer を検証し user を返す。
+ * 認証必須エンドポイント用。セッション Cookie（優先）か Bearer を検証し user を返す。
  * 失敗時は `{ user: null, response }`（401/500）、成功時 `{ user }`。
  */
 export async function requireUser(request, env) {
+  // 1. セッション Cookie（durable）
+  const cookie = readCookie(request, SESSION_COOKIE);
+  if (cookie) {
+    if (env.AUTH_MOCK === '1' && cookie === MOCK_SESSION) {
+      return { user: MOCK_USER };
+    }
+    if (env.SESSION_SECRET) {
+      try {
+        return { user: await verifySession(cookie, env.SESSION_SECRET) };
+      } catch {
+        // 無効/期限切れ Cookie → Bearer もしくは 401 へフォールバック。
+      }
+    }
+  }
+
+  // 2. Authorization: Bearer（後方互換: dev モック / Google ID トークン）
   const token = bearerToken(request);
   if (!token) {
     return { user: null, response: json({ error: 'unauthorized' }, 401) };
   }
-  // dev-only mock（本番 env に AUTH_MOCK は無いので無効）
   if (env.AUTH_MOCK === '1' && token === MOCK_ID_TOKEN) {
     return { user: MOCK_USER };
   }

--- a/functions/_shared/session.test.ts
+++ b/functions/_shared/session.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+
+import {
+  signSession,
+  verifySession,
+  sessionSetCookie,
+  sessionClearCookie,
+  readCookie,
+  requireUser,
+  MOCK_SESSION,
+} from './googleAuth.js';
+
+const SECRET = 'test-session-secret-xxxxxxxxxxxxxxxx';
+const user = { id: 'u1', email: 'a@example.com', name: 'Alice' };
+
+describe('signSession / verifySession', () => {
+  it('署名→検証でユーザーを復元する', async () => {
+    const token = await signSession(user, SECRET, 3600);
+    const got = await verifySession(token, SECRET);
+    expect(got.id).toBe('u1');
+    expect(got.email).toBe('a@example.com');
+    expect(got.name).toBe('Alice');
+  });
+
+  it('別シークレットでは検証に失敗する', async () => {
+    const token = await signSession(user, SECRET, 3600);
+    await expect(verifySession(token, 'other-secret-yyyyyyyyyyyyy')).rejects.toThrow();
+  });
+});
+
+describe('cookie ヘルパ', () => {
+  it('set は HttpOnly/Secure/SameSite=Strict/Path を含む', () => {
+    const c = sessionSetCookie('abc', 3600);
+    expect(c).toMatch(/^session=abc;/);
+    expect(c).toMatch(/HttpOnly/);
+    expect(c).toMatch(/Secure/);
+    expect(c).toMatch(/SameSite=Strict/);
+    expect(c).toMatch(/Path=\//);
+    expect(c).toMatch(/Max-Age=3600/);
+  });
+  it('clear は Max-Age=0', () => {
+    expect(sessionClearCookie()).toMatch(/Max-Age=0/);
+  });
+  it('readCookie は指定名の値を返す', () => {
+    const req = new Request('https://x/', {
+      headers: { cookie: 'a=1; session=tok123; b=2' },
+    });
+    expect(readCookie(req, 'session')).toBe('tok123');
+    expect(readCookie(req, 'missing')).toBeNull();
+  });
+});
+
+describe('requireUser: cookie 対応', () => {
+  it('有効なセッション Cookie でユーザーを返す', async () => {
+    const token = await signSession(user, SECRET, 3600);
+    const req = new Request('https://x/api/me', {
+      headers: { cookie: `session=${token}` },
+    });
+    const { user: got, response } = await requireUser(req, { SESSION_SECRET: SECRET });
+    expect(response).toBeUndefined();
+    expect(got.id).toBe('u1');
+  });
+
+  it('Cookie 無し・Bearer 無しは 401', async () => {
+    const req = new Request('https://x/api/me');
+    const { user: got, response } = await requireUser(req, { SESSION_SECRET: SECRET });
+    expect(got).toBeNull();
+    expect(response.status).toBe(401);
+  });
+
+  it('AUTH_MOCK + モックセッション Cookie で MOCK_USER', async () => {
+    const req = new Request('https://x/api/me', {
+      headers: { cookie: `session=${MOCK_SESSION}` },
+    });
+    const { user: got } = await requireUser(req, { AUTH_MOCK: '1' });
+    expect(got.id).toBe('mock-user');
+  });
+});

--- a/functions/api/session.js
+++ b/functions/api/session.js
@@ -1,0 +1,66 @@
+/**
+ * Cloudflare Pages Function: `/api/session`（#91 セッション）
+ * - POST: GIS の ID トークンを検証し、HttpOnly セッション Cookie を発行（ログイン）。
+ * - DELETE: セッション Cookie を削除（ログアウト）。
+ *
+ * セッション Cookie により、リロード後もメモリのトークン無しでログインを維持する。
+ */
+import {
+  verifyGoogleIdToken,
+  signSession,
+  sessionSetCookie,
+  sessionClearCookie,
+  MOCK_ID_TOKEN,
+  MOCK_SESSION,
+  MOCK_USER,
+  SESSION_MAX_AGE,
+} from '../_shared/googleAuth.js';
+
+function jsonWithCookie(body, status, setCookie) {
+  const headers = {
+    'content-type': 'application/json',
+    'cache-control': 'no-store',
+  };
+  if (setCookie) headers['set-cookie'] = setCookie;
+  return new Response(JSON.stringify(body), { status, headers });
+}
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonWithCookie({ error: 'bad request' }, 400);
+  }
+  const idToken = typeof body?.idToken === 'string' ? body.idToken : null;
+  if (!idToken) return jsonWithCookie({ error: 'bad request' }, 400);
+
+  // dev-only mock
+  if (env.AUTH_MOCK === '1' && idToken === MOCK_ID_TOKEN) {
+    return jsonWithCookie(
+      MOCK_USER,
+      200,
+      sessionSetCookie(MOCK_SESSION, SESSION_MAX_AGE),
+    );
+  }
+
+  if (!env.GOOGLE_CLIENT_ID || !env.SESSION_SECRET) {
+    return jsonWithCookie({ error: 'server misconfigured' }, 500);
+  }
+
+  let user;
+  try {
+    user = await verifyGoogleIdToken(idToken, env.GOOGLE_CLIENT_ID);
+  } catch {
+    return jsonWithCookie({ error: 'unauthorized' }, 401);
+  }
+
+  const session = await signSession(user, env.SESSION_SECRET, SESSION_MAX_AGE);
+  return jsonWithCookie(user, 200, sessionSetCookie(session, SESSION_MAX_AGE));
+}
+
+export function onRequestDelete() {
+  return jsonWithCookie({ ok: true }, 200, sessionClearCookie());
+}

--- a/functions/api/session.test.ts
+++ b/functions/api/session.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+
+import { onRequestPost, onRequestDelete } from './session.js';
+import { MOCK_ID_TOKEN, MOCK_SESSION, MOCK_USER } from '../_shared/googleAuth.js';
+
+function ctx(env, body) {
+  const init = { method: 'POST', headers: { 'content-type': 'application/json' } };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return { request: new Request('https://x/api/session', init), env };
+}
+
+describe('POST /api/session', () => {
+  it('モックトークンでセッション Cookie を発行し user を返す', async () => {
+    const res = await onRequestPost(ctx({ AUTH_MOCK: '1' }, { idToken: MOCK_ID_TOKEN }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(MOCK_USER);
+    const cookie = res.headers.get('set-cookie') ?? '';
+    expect(cookie).toContain(`session=${MOCK_SESSION}`);
+    expect(cookie).toMatch(/HttpOnly/);
+    expect(cookie).toMatch(/SameSite=Strict/);
+  });
+
+  it('body が不正なら 400', async () => {
+    const res = await onRequestPost(ctx({ AUTH_MOCK: '1' }, { nope: true }));
+    expect(res.status).toBe(400);
+  });
+
+  it('非モックで GOOGLE_CLIENT_ID 未設定なら 500', async () => {
+    const res = await onRequestPost(ctx({ AUTH_MOCK: '1' }, { idToken: 'real-looking' }));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('DELETE /api/session', () => {
+  it('セッション Cookie を削除する', async () => {
+    const res = await onRequestDelete({
+      request: new Request('https://x/api/session', { method: 'DELETE' }),
+      env: {},
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('set-cookie') ?? '').toMatch(/Max-Age=0/);
+  });
+});

--- a/src/data/datasources/protectedApi.ts
+++ b/src/data/datasources/protectedApi.ts
@@ -1,12 +1,14 @@
 /**
- * 認証必須 API への共通 fetch ヘルパ。`Authorization: Bearer` を付与し、
- * 200 以外は例外（`HTTP <status>`）を投げ、JSON を返す。
+ * 認証必須 API への共通 fetch ヘルパ。認証は同一オリジンの HttpOnly セッション
+ * Cookie（#91）で行うため `credentials: 'same-origin'` で Cookie を送る。`token`
+ * があるとき（アクティブセッション中）は後方互換で `Authorization: Bearer` も
+ * 付与する（リロード後は null＝Cookie のみで認証）。200 以外は例外を投げ JSON を返す。
  */
 export async function protectedRequest(
   fetchFn: typeof fetch,
   url: string,
   method: 'GET' | 'PUT',
-  token: string,
+  token: string | null,
   body?: unknown,
   timeoutMs = 10000,
 ): Promise<unknown> {
@@ -17,8 +19,9 @@ export async function protectedRequest(
   try {
     response = await fetchFn(url, {
       method,
+      credentials: 'same-origin',
       headers: {
-        authorization: `Bearer ${token}`,
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
         ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
       },
       body: body !== undefined ? JSON.stringify(body) : undefined,

--- a/src/data/datasources/registeredLibraryApiClient.ts
+++ b/src/data/datasources/registeredLibraryApiClient.ts
@@ -19,7 +19,7 @@ export class RegisteredLibraryApiClient {
     this.httpTimeoutMs = options.httpTimeoutMs ?? 10000;
   }
 
-  async getAll(token: string): Promise<Library[]> {
+  async getAll(token: string | null): Promise<Library[]> {
     const body = (await protectedRequest(
       this.fetchFn,
       this.baseUrl,
@@ -31,7 +31,7 @@ export class RegisteredLibraryApiClient {
     return Array.isArray(body.libraries) ? (body.libraries as Library[]) : [];
   }
 
-  async saveAll(token: string, libraries: Library[]): Promise<void> {
+  async saveAll(token: string | null, libraries: Library[]): Promise<void> {
     await protectedRequest(
       this.fetchFn,
       this.baseUrl,

--- a/src/data/datasources/searchHistoryApiClient.ts
+++ b/src/data/datasources/searchHistoryApiClient.ts
@@ -23,7 +23,7 @@ export class SearchHistoryApiClient {
     this.httpTimeoutMs = options.httpTimeoutMs ?? 10000;
   }
 
-  async getAll(token: string): Promise<SearchHistoryEntry[]> {
+  async getAll(token: string | null): Promise<SearchHistoryEntry[]> {
     const body = (await protectedRequest(
       this.fetchFn,
       this.baseUrl,
@@ -39,7 +39,7 @@ export class SearchHistoryApiClient {
       : [];
   }
 
-  async saveAll(token: string, entries: SearchHistoryEntry[]): Promise<void> {
+  async saveAll(token: string | null, entries: SearchHistoryEntry[]): Promise<void> {
     await protectedRequest(
       this.fetchFn,
       this.baseUrl,

--- a/src/data/datasources/sessionApiClient.test.ts
+++ b/src/data/datasources/sessionApiClient.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { SessionApiClient } from '@/data/datasources/sessionApiClient';
+
+function jsonRes(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('SessionApiClient', () => {
+  it('restore: 200 ならユーザーを返す', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonRes({ id: 'u1', name: 'Alice' }),
+    ) as unknown as typeof fetch;
+    const client = new SessionApiClient(fetchFn);
+    expect(await client.restore()).toEqual({ id: 'u1', name: 'Alice' });
+  });
+
+  it('restore: 401 なら null', async () => {
+    const fetchFn = vi.fn(async () => jsonRes({}, 401)) as unknown as typeof fetch;
+    const client = new SessionApiClient(fetchFn);
+    expect(await client.restore()).toBeNull();
+  });
+
+  it('restore: 例外でも null（投げない）', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error('network');
+    }) as unknown as typeof fetch;
+    const client = new SessionApiClient(fetchFn);
+    expect(await client.restore()).toBeNull();
+  });
+
+  it('create: /api/session に idToken を POST する', async () => {
+    let captured: { url: string; init?: RequestInit } | null = null;
+    const fetchFn = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      captured = { url: String(url), init };
+      return jsonRes({ id: 'u1' });
+    }) as unknown as typeof fetch;
+    const client = new SessionApiClient(fetchFn);
+
+    await client.create('idtok');
+
+    expect(captured!.url).toBe('/api/session');
+    expect(captured!.init?.method).toBe('POST');
+    expect(JSON.parse(String(captured!.init?.body))).toEqual({ idToken: 'idtok' });
+  });
+
+  it('destroy: /api/session に DELETE する', async () => {
+    let method: string | undefined;
+    const fetchFn = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      method = init?.method;
+      return jsonRes({ ok: true });
+    }) as unknown as typeof fetch;
+    const client = new SessionApiClient(fetchFn);
+
+    await client.destroy();
+    expect(method).toBe('DELETE');
+  });
+});

--- a/src/data/datasources/sessionApiClient.ts
+++ b/src/data/datasources/sessionApiClient.ts
@@ -1,0 +1,53 @@
+import type { User } from '@/domain/models/user';
+
+/**
+ * セッション操作の抽象（#91）。AuthProvider から注入してテスト可能にする。
+ */
+export interface SessionApi {
+  /** Cookie からセッションを復元する（未ログイン/失敗は null）。 */
+  restore(): Promise<User | null>;
+  /** GIS の ID トークンを送り、セッション Cookie を発行する。 */
+  create(idToken: string): Promise<void>;
+  /** セッション Cookie を削除する（ログアウト）。 */
+  destroy(): Promise<void>;
+}
+
+/**
+ * `/api/session`（POST/DELETE）と `/api/me`（GET）を叩く実装。
+ * 認証は HttpOnly Cookie のため `credentials: 'same-origin'` で Cookie を送る。
+ */
+export class SessionApiClient implements SessionApi {
+  constructor(
+    private readonly fetchFn: typeof fetch = globalThis.fetch.bind(globalThis),
+    private readonly baseUrl: string = '/api',
+  ) {}
+
+  async restore(): Promise<User | null> {
+    try {
+      const res = await this.fetchFn(`${this.baseUrl}/me`, {
+        credentials: 'same-origin',
+      });
+      if (res.status !== 200) return null;
+      const user = (await res.json()) as User;
+      return user && typeof user.id === 'string' ? user : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async create(idToken: string): Promise<void> {
+    await this.fetchFn(`${this.baseUrl}/session`, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ idToken }),
+    });
+  }
+
+  async destroy(): Promise<void> {
+    await this.fetchFn(`${this.baseUrl}/session`, {
+      method: 'DELETE',
+      credentials: 'same-origin',
+    });
+  }
+}

--- a/src/data/repositories/serverRegisteredLibraryRepositoryImpl.test.ts
+++ b/src/data/repositories/serverRegisteredLibraryRepositoryImpl.test.ts
@@ -82,8 +82,10 @@ describe('ServerRegisteredLibraryRepositoryImpl', () => {
     expect((await repo.remove(lib('S1'))).map((l) => l.systemId)).toEqual(['S2']);
   });
 
-  it('未認証（トークン無し）は例外', async () => {
+  it('トークン無し（リロード後）でも Cookie 認証前提で API に委譲する', async () => {
+    // #91: 認証は HttpOnly Cookie が主。トークン null でも例外にせず委譲し、
+    // 未認証は API の 401 として表面化する（ここでは Fake が空配列を返す）。
     const repo = new ServerRegisteredLibraryRepositoryImpl(new FakeApi() as never, () => null);
-    await expect(repo.getAll()).rejects.toThrow();
+    await expect(repo.getAll()).resolves.toEqual([]);
   });
 });

--- a/src/data/repositories/serverRegisteredLibraryRepositoryImpl.ts
+++ b/src/data/repositories/serverRegisteredLibraryRepositoryImpl.ts
@@ -18,12 +18,11 @@ export class ServerRegisteredLibraryRepositoryImpl
     private readonly tokenProvider: () => string | null = getAuthToken,
   ) {}
 
-  private token(): string {
-    const token = this.tokenProvider();
-    if (token === null || token.length === 0) {
-      throw new Error('Not authenticated');
-    }
-    return token;
+  // 認証は HttpOnly セッション Cookie（#91）が主。リロード後はメモリにトークンが
+  // 無い（null）が、Cookie で認証されるため例外にしない。未認証は API の 401 として
+  // 表面化する。アクティブセッション中は後方互換で Bearer も併送される。
+  private token(): string | null {
+    return this.tokenProvider();
   }
 
   async getAll(): Promise<Library[]> {

--- a/src/data/repositories/serverSearchHistoryRepositoryImpl.test.ts
+++ b/src/data/repositories/serverSearchHistoryRepositoryImpl.test.ts
@@ -59,8 +59,9 @@ describe('ServerSearchHistoryRepositoryImpl', () => {
     expect(await repo.getAll()).toEqual([]);
   });
 
-  it('未認証は例外', async () => {
+  it('トークン無し（リロード後）でも Cookie 認証前提で API に委譲する', async () => {
+    // #91: 認証は HttpOnly Cookie が主。トークン null でも例外にしない。
     const repo = new ServerSearchHistoryRepositoryImpl(new FakeApi() as never, () => null);
-    await expect(repo.getAll()).rejects.toThrow();
+    await expect(repo.getAll()).resolves.toEqual([]);
   });
 });

--- a/src/data/repositories/serverSearchHistoryRepositoryImpl.ts
+++ b/src/data/repositories/serverSearchHistoryRepositoryImpl.ts
@@ -16,12 +16,10 @@ export class ServerSearchHistoryRepositoryImpl
     private readonly tokenProvider: () => string | null = getAuthToken,
   ) {}
 
-  private token(): string {
-    const token = this.tokenProvider();
-    if (token === null || token.length === 0) {
-      throw new Error('Not authenticated');
-    }
-    return token;
+  // 認証は HttpOnly セッション Cookie（#91）が主。リロード後はトークンが null でも
+  // Cookie で認証されるため例外にしない（未認証は API の 401 として表面化）。
+  private token(): string | null {
+    return this.tokenProvider();
   }
 
   async getAll(): Promise<SearchHistoryEntry[]> {

--- a/src/presentation/auth/AuthProvider.test.tsx
+++ b/src/presentation/auth/AuthProvider.test.tsx
@@ -1,14 +1,25 @@
-import { describe, it, expect } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 
 import { AuthProvider, useAuth } from '@/presentation/auth/AuthProvider';
+import type { SessionApi } from '@/data/datasources/sessionApiClient';
 import type { User } from '@/domain/models/user';
 
 const alice: User = { id: 'u1', name: 'Alice', email: 'a@example.com' };
 
+/** ネットワークを使わない no-op セッション（既定は未復元）。 */
+function fakeSession(overrides: Partial<SessionApi> = {}): SessionApi {
+  return {
+    restore: async () => null,
+    create: async () => {},
+    destroy: async () => {},
+    ...overrides,
+  };
+}
+
 function wrapper({ children }: { children: ReactNode }) {
-  return <AuthProvider>{children}</AuthProvider>;
+  return <AuthProvider sessionApi={fakeSession()}>{children}</AuthProvider>;
 }
 
 describe('AuthProvider / useAuth', () => {
@@ -44,5 +55,47 @@ describe('AuthProvider / useAuth', () => {
 
   it('Provider 外で useAuth を呼ぶと例外', () => {
     expect(() => renderHook(() => useAuth())).toThrow();
+  });
+});
+
+describe('AuthProvider セッション（#91）', () => {
+  it('マウント時に restore でセッションを復元する', async () => {
+    const session = fakeSession({ restore: async () => alice });
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => (
+        <AuthProvider sessionApi={session}>{children}</AuthProvider>
+      ),
+    });
+    await waitFor(() => expect(result.current.user).toEqual(alice));
+  });
+
+  it('initialUser がある場合は restore しない', () => {
+    const restore = vi.fn(async () => alice);
+    renderHook(() => useAuth(), {
+      wrapper: ({ children }) => (
+        <AuthProvider initialUser={alice} sessionApi={fakeSession({ restore })}>
+          {children}
+        </AuthProvider>
+      ),
+    });
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it('signIn は create、signOut は destroy を呼ぶ', async () => {
+    const create = vi.fn(async () => {});
+    const destroy = vi.fn(async () => {});
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => (
+        <AuthProvider sessionApi={fakeSession({ create, destroy })}>
+          {children}
+        </AuthProvider>
+      ),
+    });
+
+    act(() => result.current.signIn(alice, 'idtok'));
+    expect(create).toHaveBeenCalledWith('idtok');
+
+    act(() => result.current.signOut());
+    expect(destroy).toHaveBeenCalled();
   });
 });

--- a/src/presentation/auth/AuthProvider.tsx
+++ b/src/presentation/auth/AuthProvider.tsx
@@ -3,6 +3,10 @@ import type { ReactNode } from 'react';
 
 import type { User } from '@/domain/models/user';
 import { setAuthToken } from '@/data/datasources/authTokenStore';
+import {
+  SessionApiClient,
+  type SessionApi,
+} from '@/data/datasources/sessionApiClient';
 
 export interface AuthContextValue {
   /** ログイン中のユーザー。未ログインは null。 */
@@ -20,44 +24,70 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 /**
  * 認証状態（ユーザー / ID トークン）をアプリ全体に提供する。
  *
- * ID トークンはメモリ保持（リロードで消える＝GIS で再取得）。`initialUser` /
- * `initialIdToken` はテストやモック起動時の初期状態注入に使う。
+ * セッションは HttpOnly Cookie で維持する（#91）。マウント時に `sessionApi.restore()`
+ * （= GET /api/me）でセッションを復元するため、リロードしても再認証不要。`signIn` は
+ * Cookie を発行（POST /api/session）、`signOut` は削除（DELETE /api/session）する。
+ * ID トークンはアクティブセッション中のみメモリ保持（後方互換 Bearer）。
+ * `initialUser` / `initialIdToken` はテスト用の初期状態注入（指定時は復元しない）。
  */
 export function AuthProvider({
   children,
   initialUser = null,
   initialIdToken = null,
+  sessionApi,
 }: {
   children: ReactNode;
   initialUser?: User | null;
   initialIdToken?: string | null;
+  sessionApi?: SessionApi;
 }): JSX.Element {
   const [user, setUser] = useState<User | null>(initialUser);
   const [idToken, setIdToken] = useState<string | null>(initialIdToken);
+
+  const session = useMemo<SessionApi>(
+    () => sessionApi ?? new SessionApiClient(),
+    [sessionApi],
+  );
 
   // 現在の ID トークンを AuthTokenStore に同期（サーバー版リポジトリが参照）。
   useEffect(() => {
     setAuthToken(idToken);
   }, [idToken]);
 
+  // マウント時にセッションを復元（initialUser 注入時はスキップ）。
+  useEffect(() => {
+    if (initialUser) return;
+    let cancelled = false;
+    void session.restore().then((restored) => {
+      if (!cancelled && restored) setUser(restored);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // セッション復元は初回マウントのみ。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const value = useMemo<AuthContextValue>(
     () => ({
       user,
       idToken,
       signIn: (nextUser, nextToken) => {
-        // トークンは同期的に反映する（再レンダー後のクエリが古い/未設定トークンを
-        // 読むのを防ぐ。effect 同期はマウント時の initialIdToken 用）。
+        // 状態は同期的に反映（再レンダー後のクエリが古い/未設定トークンを読むのを防ぐ）。
         setAuthToken(nextToken);
         setUser(nextUser);
         setIdToken(nextToken);
+        // セッション Cookie を発行（失敗は握りつぶす＝UI を壊さない）。
+        void session.create(nextToken).catch(() => {});
       },
       signOut: () => {
         setAuthToken(null);
         setUser(null);
         setIdToken(null);
+        void session.destroy().catch(() => {});
       },
     }),
-    [user, idToken],
+    [user, idToken, session],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/vite-dev-persistence.ts
+++ b/vite-dev-persistence.ts
@@ -130,9 +130,18 @@ export function devPersistencePlugin(): Plugin {
         db.exec(stmt + ";");
       }
 
-      const env = { DB: makeD1Adapter(db), AUTH_MOCK: "1", GOOGLE_CLIENT_ID: "dev" };
+      const env = {
+        DB: makeD1Adapter(db),
+        AUTH_MOCK: "1",
+        GOOGLE_CLIENT_ID: "dev",
+        SESSION_SECRET: "dev-session-secret",
+      };
 
       const routes: Record<string, string> = {
+        // 認証・セッションも本番と同じ function を実行し、ローカルでも
+        // 「mock ログイン → Cookie 発行 → リロードで /api/me 復元」を再現する。
+        "/api/session": "functions/api/session.js",
+        "/api/me": "functions/api/me.js",
         "/api/registered-libraries": "functions/api/registered-libraries.js",
         "/api/search-history": "functions/api/search-history.js",
       };
@@ -145,14 +154,20 @@ export function devPersistencePlugin(): Plugin {
               const mod = (await import(moduleUrl)) as {
                 onRequestGet?: (c: unknown) => Promise<Response>;
                 onRequestPut?: (c: unknown) => Promise<Response>;
+                onRequestPost?: (c: unknown) => Promise<Response>;
+                onRequestDelete?: (c: unknown) => Promise<Response>;
               };
               const request = await toWebRequest(req);
-              const handler =
-                request.method === "GET"
-                  ? mod.onRequestGet
-                  : request.method === "PUT"
-                    ? mod.onRequestPut
-                    : undefined;
+              const byMethod: Record<
+                string,
+                ((c: unknown) => Promise<Response>) | undefined
+              > = {
+                GET: mod.onRequestGet,
+                PUT: mod.onRequestPut,
+                POST: mod.onRequestPost,
+                DELETE: mod.onRequestDelete,
+              };
+              const handler = byMethod[request.method];
               if (handler === undefined) {
                 res.statusCode = 405;
                 res.end();


### PR DESCRIPTION
Closes #91

## 概要

ID トークンをメモリのみで保持していたため、リロードで毎回 Google 再認証を求められていた。サーバ発行の **HttpOnly Cookie セッション**で「リロードしても維持」を実現する。HttpOnly により XSS でのトークン窃取が不可、SameSite=Strict で CSRF を防ぐ（＝UX 改善かつセキュリティ向上）。

## 変更点

### サーバ
- `_shared/googleAuth.js`: `signSession`/`verifySession`（HS256・`SESSION_SECRET`）、Cookie ヘルパ（HttpOnly/Secure/SameSite=Strict/Path=/）、`readCookie`。`requireUser` を **セッション Cookie 優先**に拡張（既存 Bearer も後方互換で受理 → 既存サーバテストは無改変で緑）。
- `functions/api/session.js`: `POST`（GIS トークンを検証し Cookie 発行）/ `DELETE`（Cookie 削除）。

### クライアント
- `AuthProvider`: マウント時に `GET /api/me` でセッション復元（`initialUser` 注入時はスキップ）。`signIn` で `POST /api/session`、`signOut` で `DELETE`。失敗は握りつぶす。`sessionApi` 注入可。
- 保護クライアント/リポジトリ/Calil を **Cookie 前提**に（`credentials: 'same-origin'`、`token` 任意）。リロード後はメモリにトークンが無くても Cookie で認証。

### dev
- `vite-dev-persistence` が `/api/session`・`/api/me` も実行し `SESSION_SECRET` を付与。ローカルでも本番同等の「mock ログイン→Cookie→リロード復元」を再現。

## セキュリティ
- HttpOnly（JS から読めない）/ Secure / SameSite=Strict（GIS は JS ログインでリダイレクト不要のため Strict 可）。セッション JWT は `SESSION_SECRET`(HS256) 署名でクライアントに出ない。

## ⚠️ デプロイ前提
- 本番 Pages プロジェクトに **`SESSION_SECRET`（secret_text）** が必要。**未設定でも回帰なし**（Cookie 未発行で従来の挙動にフォールバックし、Bearer で当該セッションは動作）だが、リロード維持を有効化するには設定が必須。

## Test Plan
- [x] session sign/verify・Cookie ヘルパ・`requireUser` Cookie 対応（8）
- [x] `/api/session` POST/DELETE（4）
- [x] `sessionApiClient` restore/create/destroy（5）
- [x] `AuthProvider` 復元/create/destroy（3）＋既存 auth テスト維持
- [x] 既存サーバテスト（Bearer モック）無改変で緑
- [x] `npx tsc -b` / `npm test` 緑（336）
- [ ] （デプロイ後）`SESSION_SECRET` 設定 → 本番でログイン→**リロードで維持**、ログアウト→401 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)