### PR TITLE
予約を window.open からリンク(<a>)へ（#95 P1-1）

### DIFF
--- a/src/presentation/widgets/LibraryAvailabilityCard.test.tsx
+++ b/src/presentation/widgets/LibraryAvailabilityCard.test.tsx
@@ -129,8 +129,7 @@ describe('LibraryAvailabilityCard', () => {
     expect(screen.queryByText('予約する')).not.toBeInTheDocument();
   });
 
-  test('opens reserve URL in a new tab when reserve button is tapped', async () => {
-    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+  test('予約は新しいタブで開く安全なリンクとして描画される', () => {
     const status: LibraryStatus = {
       systemId: 'Tokyo_Minato',
       status: AvailabilityStatus.available,
@@ -138,16 +137,13 @@ describe('LibraryAvailabilityCard', () => {
       libKeyStatuses: { みなと: '貸出可' },
     };
 
-    const { user } = renderWithProviders(
+    renderWithProviders(
       <LibraryAvailabilityCard library={library} status={status} />,
     );
 
-    await user.click(screen.getByText('予約する'));
-
-    expect(openSpy).toHaveBeenCalledWith(
-      'https://example.com/reserve',
-      '_blank',
-      'noopener,noreferrer',
-    );
+    const link = screen.getByRole('link', { name: '予約する' });
+    expect(link).toHaveAttribute('href', 'https://example.com/reserve');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link.getAttribute('rel') ?? '').toContain('noopener');
   });
 });

--- a/src/presentation/widgets/LibraryAvailabilityCard.tsx
+++ b/src/presentation/widgets/LibraryAvailabilityCard.tsx
@@ -60,9 +60,9 @@ export function LibraryAvailabilityCard({
             <Box sx={{ height: 8 }} />
             <Button
               variant="text"
-              onClick={() => {
-                window.open(reserveUrl, '_blank', 'noopener,noreferrer');
-              }}
+              href={reserveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
             >
               予約する
             </Button>


### PR DESCRIPTION
Part of #95（フロントレビュー P1）

## 変更
`LibraryAvailabilityCard` の「予約する」を `onClick + window.open` から `Button href/target="_blank"/rel="noopener noreferrer"`（＝アンカー）へ。

## 理由
- `window.open` はポップアップブロックされ得る／中クリック・新規タブが効かない／スクリーンリーダーがリンクと認識しない
- 「Amazonで見る」（既にアンカー）と挙動・実装を統一

## Test Plan
- [x] 予約リンクの href/target/rel を検証（テスト更新）
- [x] 予約不可・javascript: スキームでリンク非表示（既存テスト維持）
- [x] `npx tsc -b` / `npm test` 緑（336）

🤖 Generated with [Claude Code](https://claude.com/claude-code)