### PR TITLE
スペーサー Box を Stack/gap/mt へ置換（#95 P1-2）

### DIFF
--- a/src/presentation/pages/BookSearchResultPage.tsx
+++ b/src/presentation/pages/BookSearchResultPage.tsx
@@ -106,9 +106,8 @@ export function BookSearchResultPage(): JSX.Element {
 
   const isbnSection = (
     <Card>
-      <Box sx={{ p: 2, display: 'flex', alignItems: 'center' }}>
+      <Box sx={{ p: 2, display: 'flex', alignItems: 'center', gap: 1.5 }}>
         <BookIcon sx={{ fontSize: 24 }} />
-        <Box sx={{ width: 12 }} />
         <Typography variant="body1">{`ISBN: ${isbn}`}</Typography>
       </Box>
     </Card>
@@ -118,15 +117,14 @@ export function BookSearchResultPage(): JSX.Element {
   // タイトル取得（OpenBD）が失敗・未取得でも常に表示できる。メタデータ取得の
   // 失敗はページ全体のエラー表示には波及させない（中核機能の蔵書状況は無影響）。
   const bookMetadataSection = (
-    <>
-      <Box sx={{ height: 16 }} />
+    <Box sx={{ mt: 2 }}>
       <BookMetadataCard
         isbn={isbn}
         title={metadataQuery.data?.title}
         openBdCoverUrl={metadataQuery.data?.coverImageUrl}
         isLoadingTitle={metadataQuery.isLoading}
       />
-    </>
+    </Box>
   );
 
   const scanAnotherButton = (
@@ -158,64 +156,58 @@ export function BookSearchResultPage(): JSX.Element {
   );
 
   const errorState = (error: unknown): JSX.Element => (
-    <Box sx={{ p: 2 }}>
+    <Box sx={{ p: 2, display: 'flex', flexDirection: 'column' }}>
       {isbnSection}
       {bookMetadataSection}
-      <Box sx={{ height: 24 }} />
       <Box
         sx={{
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
+          mt: 3,
         }}
       >
         <ErrorOutlineIcon sx={{ fontSize: 48, color: APP_COLORS.error }} />
-        <Box sx={{ height: 16 }} />
-        <Typography>{resolveErrorMessage(error)}</Typography>
-        <Box sx={{ height: 16 }} />
-        <Button variant="contained" onClick={handleRetry}>
+        <Typography sx={{ mt: 2 }}>{resolveErrorMessage(error)}</Typography>
+        <Button variant="contained" onClick={handleRetry} sx={{ mt: 2 }}>
           再試行
         </Button>
       </Box>
-      <Box sx={{ height: 24 }} />
-      {scanAnotherButton}
+      <Box sx={{ mt: 3 }}>{scanAnotherButton}</Box>
     </Box>
   );
 
   const loadingState = (
-    <Box sx={{ p: 2 }}>
+    <Box sx={{ p: 2, display: 'flex', flexDirection: 'column' }}>
       {isbnSection}
       {bookMetadataSection}
-      <Box sx={{ height: 24 }} />
-      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 3 }}>
         <CircularProgress />
       </Box>
-      <Box sx={{ height: 16 }} />
-      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
         <Typography>蔵書を検索中...</Typography>
       </Box>
     </Box>
   );
 
   const noLibraryState = (
-    <Box sx={{ p: 2 }}>
+    <Box sx={{ p: 2, display: 'flex', flexDirection: 'column' }}>
       {isbnSection}
-      <Box sx={{ height: 24 }} />
       <Box
         sx={{
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
+          mt: 3,
         }}
       >
         <LocalLibraryIcon sx={{ fontSize: 48, color: APP_COLORS.inactive }} />
-        <Box sx={{ height: 16 }} />
-        <Typography>図書館が登録されていません</Typography>
-        <Box sx={{ height: 8 }} />
-        <Typography>図書館を登録すると蔵書を検索できます</Typography>
+        <Typography sx={{ mt: 2 }}>図書館が登録されていません</Typography>
+        <Typography sx={{ mt: 1 }}>
+          図書館を登録すると蔵書を検索できます
+        </Typography>
       </Box>
-      <Box sx={{ height: 24 }} />
-      {addLibraryButton}
+      <Box sx={{ mt: 3 }}>{addLibraryButton}</Box>
     </Box>
   );
 
@@ -225,31 +217,32 @@ export function BookSearchResultPage(): JSX.Element {
   ): JSX.Element => {
     const result = findResultForIsbn(results);
     return (
-      <Box sx={{ p: 2 }}>
+      <Box sx={{ p: 2, display: 'flex', flexDirection: 'column' }}>
         {isbnSection}
         {bookMetadataSection}
-        <Box sx={{ height: 24 }} />
-        <Typography variant="subtitle1">蔵書状況</Typography>
-        <Box sx={{ height: 8 }} />
-        {results.length > 0 ? (
-          sortLibrariesByAvailability(libraries, result).map((library) => {
-            const status = result?.libraryStatuses[library.systemId];
-            if (status === undefined) return null;
-            return (
-              <LibraryAvailabilityCard
-                key={libraryKey(library)}
-                library={library}
-                status={status}
-              />
-            );
-          })
-        ) : (
-          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-            <Typography>検索結果がありません</Typography>
-          </Box>
-        )}
-        <Box sx={{ height: 24 }} />
-        {scanAnotherButton}
+        <Typography variant="subtitle1" sx={{ mt: 3 }}>
+          蔵書状況
+        </Typography>
+        <Box sx={{ mt: 1 }}>
+          {results.length > 0 ? (
+            sortLibrariesByAvailability(libraries, result).map((library) => {
+              const status = result?.libraryStatuses[library.systemId];
+              if (status === undefined) return null;
+              return (
+                <LibraryAvailabilityCard
+                  key={libraryKey(library)}
+                  library={library}
+                  status={status}
+                />
+              );
+            })
+          ) : (
+            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+              <Typography>検索結果がありません</Typography>
+            </Box>
+          )}
+        </Box>
+        <Box sx={{ mt: 3 }}>{scanAnotherButton}</Box>
       </Box>
     );
   };

--- a/src/presentation/pages/HomePage.tsx
+++ b/src/presentation/pages/HomePage.tsx
@@ -65,23 +65,22 @@ export function HomePage(): React.ReactElement {
           <MenuBookIcon
             sx={{ fontSize: 64, color: theme.palette.primary.main }}
           />
-          <Box sx={{ height: 16 }} />
-          <Typography variant="h6">図書館の蔵書をかんたん検索</Typography>
-          <Box sx={{ height: 32 }} />
+          <Typography variant="h6" sx={{ mt: 2 }}>
+            図書館の蔵書をかんたん検索
+          </Typography>
           <Button
             variant="contained"
             startIcon={<QrCodeScannerIcon />}
             onClick={() => navigate('/scan')}
-            sx={{ width: '100%', minHeight: 56 }}
+            sx={{ width: '100%', minHeight: 56, mt: 4 }}
           >
             バーコードでスキャン
           </Button>
-          <Box sx={{ height: 16 }} />
           <Button
             variant="outlined"
             startIcon={<KeyboardIcon />}
             onClick={() => navigate('/isbn-input')}
-            sx={{ width: '100%', minHeight: 56 }}
+            sx={{ width: '100%', minHeight: 56, mt: 2 }}
           >
             ISBNを入力
           </Button>

--- a/src/presentation/pages/IsbnInputPage.tsx
+++ b/src/presentation/pages/IsbnInputPage.tsx
@@ -39,9 +39,9 @@ export function IsbnInputPage(): React.ReactElement {
       <SubPageAppBar title="ISBN入力" />
       <Box sx={{ p: 2 }}>
         <Typography variant="h6">ISBNを入力してください</Typography>
-        <Box sx={{ height: 16 }} />
         <TextField
           fullWidth
+          sx={{ mt: 2 }}
           value={value}
           onChange={(event) => setValue(event.target.value)}
           // ISBN はハイフン区切りで入力されることがあり、ISBN-10 のチェック
@@ -52,27 +52,29 @@ export function IsbnInputPage(): React.ReactElement {
           error={errorText !== null}
           helperText={errorText ?? undefined}
         />
-        <Box sx={{ height: 8 }} />
         {showValid && (
-          <Typography sx={{ color: theme.palette.primary.main }}>
+          <Typography sx={{ color: theme.palette.primary.main, mt: 1 }}>
             有効なISBNです
           </Typography>
         )}
-        <Box sx={{ height: 8 }} />
-        <Typography variant="caption" component="p">
+        <Typography variant="caption" component="p" sx={{ mt: 1 }}>
           書籍の裏表紙に記載されている13桁の数字を入力してください。
         </Typography>
-        <Box sx={{ height: 24 }} />
         <Button
           variant="contained"
           fullWidth
           disabled={!isValid}
           onClick={onSubmit}
+          sx={{ mt: 3 }}
         >
           検索する
         </Button>
-        <Box sx={{ height: 12 }} />
-        <Button variant="outlined" fullWidth onClick={navigateToScan}>
+        <Button
+          variant="outlined"
+          fullWidth
+          onClick={navigateToScan}
+          sx={{ mt: 1.5 }}
+        >
           バーコードスキャンへ
         </Button>
       </Box>

--- a/src/presentation/pages/LibraryListPage.tsx
+++ b/src/presentation/pages/LibraryListPage.tsx
@@ -65,8 +65,7 @@ export function LibraryListPage(): JSX.Element {
           }}
         >
           <CircularProgress />
-          <Box sx={{ height: 16 }} />
-          <Typography>図書館を検索中...</Typography>
+          <Typography sx={{ mt: 2 }}>図書館を検索中...</Typography>
         </Box>
       );
     }

--- a/src/presentation/pages/LoginPage.tsx
+++ b/src/presentation/pages/LoginPage.tsx
@@ -27,7 +27,6 @@ export function LoginPage(): JSX.Element {
       <Typography color="text.secondary" sx={{ whiteSpace: 'pre-line' }}>
         {'ログインすると、登録した図書館と検索履歴を\nどの端末でも使えます。'}
       </Typography>
-      <Box sx={{ height: 8 }} />
       <GoogleSignInControl oneTap />
     </Box>
   );

--- a/src/presentation/widgets/AvailabilityStatusBadge.tsx
+++ b/src/presentation/widgets/AvailabilityStatusBadge.tsx
@@ -54,9 +54,8 @@ export function AvailabilityStatusBadge({
   const { label, color, Icon } = statusInfo(status);
 
   return (
-    <Box sx={{ display: 'inline-flex', alignItems: 'center' }}>
+    <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
       <Icon sx={{ color, fontSize: 20 }} />
-      <Box sx={{ width: 4 }} />
       <Typography component="span" sx={{ color, fontWeight: 'bold' }}>
         {label}
       </Typography>

--- a/src/presentation/widgets/BookMetadataCard.tsx
+++ b/src/presentation/widgets/BookMetadataCard.tsx
@@ -120,9 +120,8 @@ export function BookMetadataCard({
 
   return (
     <Card sx={{ my: 1 }}>
-      <Box sx={{ p: 2, display: 'flex', alignItems: 'flex-start' }}>
+      <Box sx={{ p: 2, display: 'flex', alignItems: 'flex-start', gap: 2 }}>
         <Box sx={{ flexShrink: 0 }}>{coverArea}</Box>
-        <Box sx={{ width: 16 }} />
         <Box
           sx={{
             flex: 1,
@@ -133,27 +132,25 @@ export function BookMetadataCard({
           }}
         >
           {titleArea}
-          <Box sx={{ height: 12 }} />
           <Button
             variant="outlined"
             startIcon={<OpenInNewIcon />}
             href={productUrl}
             target="_blank"
             rel="noopener noreferrer"
+            sx={{ mt: 1.5 }}
           >
             Amazonで見る
           </Button>
           {showAffiliateDisclosure && (
-            <>
-              <Box sx={{ height: 8 }} />
-              <Typography
-                data-testid="affiliate-disclosure"
-                variant="caption"
-                color="text.secondary"
-              >
-                ※Amazonのアソシエイトとして、LibCheckは適格販売により収入を得ています。
-              </Typography>
-            </>
+            <Typography
+              data-testid="affiliate-disclosure"
+              variant="caption"
+              color="text.secondary"
+              sx={{ mt: 1 }}
+            >
+              ※Amazonのアソシエイトとして、LibCheckは適格販売により収入を得ています。
+            </Typography>
           )}
         </Box>
       </Box>

--- a/src/presentation/widgets/CameraErrorWidget.tsx
+++ b/src/presentation/widgets/CameraErrorWidget.tsx
@@ -33,29 +33,27 @@ export function CameraErrorWidget({
         }}
       >
         <VideocamOffOutlinedIcon sx={{ fontSize: 64, color: 'text.secondary' }} />
-        <Box sx={{ height: 24 }} />
-        <Typography variant="subtitle1" align="center">
+        <Typography variant="subtitle1" align="center" sx={{ mt: 3 }}>
           カメラの起動に失敗しました
         </Typography>
-        <Box sx={{ height: 8 }} />
-        <Typography variant="body2" align="center">
+        <Typography variant="body2" align="center" sx={{ mt: 1 }}>
           しばらくしてからもう一度お試しください。
         </Typography>
-        <Box sx={{ height: 32 }} />
         <Button
           fullWidth
           variant="contained"
           startIcon={<RefreshIcon />}
           onClick={onRetry}
+          sx={{ mt: 4 }}
         >
           再試行
         </Button>
-        <Box sx={{ height: 12 }} />
         <Button
           fullWidth
           variant="outlined"
           startIcon={<KeyboardIcon />}
           onClick={onManualInput}
+          sx={{ mt: 1.5 }}
         >
           ISBNを手動入力する
         </Button>

--- a/src/presentation/widgets/CameraPermissionErrorWidget.tsx
+++ b/src/presentation/widgets/CameraPermissionErrorWidget.tsx
@@ -40,30 +40,28 @@ export function CameraPermissionErrorWidget({
         }}
       >
         <CameraAltOutlinedIcon sx={{ fontSize: 64, color: 'text.secondary' }} />
-        <Box sx={{ height: 24 }} />
-        <Typography variant="subtitle1" align="center">
+        <Typography variant="subtitle1" align="center" sx={{ mt: 3 }}>
           カメラへのアクセスが許可されていません
         </Typography>
-        <Box sx={{ height: 8 }} />
-        <Typography variant="body2" align="center">
+        <Typography variant="body2" align="center" sx={{ mt: 1 }}>
           バーコードをスキャンするには、ブラウザの設定でカメラへのアクセスを許可してください。
           アドレスバーのカメラアイコン、またはサイトの設定から変更できます。
         </Typography>
-        <Box sx={{ height: 32 }} />
         <Button
           fullWidth
           variant="contained"
           startIcon={<RefreshIcon />}
           onClick={onRetry}
+          sx={{ mt: 4 }}
         >
           再試行
         </Button>
-        <Box sx={{ height: 12 }} />
         <Button
           fullWidth
           variant="outlined"
           startIcon={<KeyboardIcon />}
           onClick={onManualInput}
+          sx={{ mt: 1.5 }}
         >
           ISBNを手動入力する
         </Button>

--- a/src/presentation/widgets/ErrorStateWidget.tsx
+++ b/src/presentation/widgets/ErrorStateWidget.tsx
@@ -34,12 +34,10 @@ export function ErrorStateWidget({
         }}
       >
         <ErrorOutlineIcon sx={{ fontSize: 48, color: APP_COLORS.error }} />
-        <Box sx={{ height: 16 }} />
-        <Typography variant="body1" align="center">
+        <Typography variant="body1" align="center" sx={{ mt: 2 }}>
           {resolveErrorMessage(error)}
         </Typography>
-        <Box sx={{ height: 16 }} />
-        <Button variant="contained" onClick={onRetry}>
+        <Button variant="contained" onClick={onRetry} sx={{ mt: 2 }}>
           再試行
         </Button>
       </Box>

--- a/src/presentation/widgets/LibraryAvailabilityCard.tsx
+++ b/src/presentation/widgets/LibraryAvailabilityCard.tsx
@@ -42,31 +42,28 @@ export function LibraryAvailabilityCard({
   return (
     <Card sx={{ my: 1 }}>
       <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', width: '100%' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', gap: 1 }}>
           <LocalLibraryIcon sx={{ fontSize: 20 }} />
-          <Box sx={{ width: 8 }} />
           <Typography variant="subtitle1" sx={{ flex: 1 }}>
             {library.formalName}
           </Typography>
         </Box>
-        <Box sx={{ height: 4 }} />
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
           {`${library.pref}${library.city}`}
         </Typography>
-        <Box sx={{ height: 12 }} />
-        <AvailabilityStatusBadge status={libKeyStatus} />
+        <Box sx={{ mt: 1.5 }}>
+          <AvailabilityStatusBadge status={libKeyStatus} />
+        </Box>
         {showReserve && (
-          <>
-            <Box sx={{ height: 8 }} />
-            <Button
-              variant="text"
-              href={reserveUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              予約する
-            </Button>
-          </>
+          <Button
+            variant="text"
+            href={reserveUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ mt: 1 }}
+          >
+            予約する
+          </Button>
         )}
       </Box>
     </Card>

--- a/src/presentation/widgets/SearchHistoryCard.tsx
+++ b/src/presentation/widgets/SearchHistoryCard.tsx
@@ -68,18 +68,16 @@ export function SearchHistoryCard({
       <CardActionArea onClick={onTap} sx={{ borderRadius: 3 }}>
         <Box sx={{ p: 2, display: 'flex', alignItems: 'center' }}>
           <BookIcon sx={{ fontSize: 24 }} />
-          <Box sx={{ width: 12 }} />
-          <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', ml: 1.5 }}>
             <Typography variant="body1">{`ISBN: ${entry.isbn}`}</Typography>
-            <Box sx={{ height: 4 }} />
-            <Typography variant="body2" color="text.secondary">
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
               {formatDate(entry.searchedAt, now)}
             </Typography>
           </Box>
-          <Box sx={{ width: 8 }} />
-          <AvailabilityStatusBadge status={bestStatus(entry)} />
-          <Box sx={{ width: 4 }} />
-          <ChevronRightIcon sx={{ color: 'text.secondary' }} />
+          <Box sx={{ ml: 1 }}>
+            <AvailabilityStatusBadge status={bestStatus(entry)} />
+          </Box>
+          <ChevronRightIcon sx={{ color: 'text.secondary', ml: 0.5 }} />
         </Box>
       </CardActionArea>
     </Card>


### PR DESCRIPTION
Part of #95（フロントレビュー P1）

## 変更
Flutter `SizedBox` 直訳の `<Box sx={{ height/width: N }} />`（**47箇所/12ファイル**）を撤去し、MUI の余白（行は `gap`、縦は `mt`）へ。**8px 単位を厳密保持**し、flex コンテナ内では spacer ≡ margin で構造的にピクセル等価。`BookSearchResultPage` の各状態コンテナは flex column 化してマージン相殺を防止。

## 対象
HomePage / LoginPage / IsbnInputPage / LibraryListPage / BookSearchResultPage / BookMetadataCard / LibraryAvailabilityCard / AvailabilityStatusBadge / ErrorStateWidget / CameraErrorWidget / CameraPermissionErrorWidget / SearchHistoryCard

## 軽微な意図的差分（≤16px・一貫性向上方向）
- LoginPage: 余分な空 Box を除去し container の `gap` に一本化
- IsbnInputPage: 無効状態の補足文の上余白（二重スペーサー由来 16→8px）
- 書影カード前の余白（カード自身の `my` と spacer の二重 24→16px）

## Test Plan
- [x] 残存スペーサー 0（grep）
- [x] `npx tsc -b` / `npm test` 緑（336、挙動不変）
- [ ] ⚠️（要メンテナー目視）本番相当で各画面の余白崩れが無いこと。実ブラウザがこの環境で使えないため未実施。8px 単位保持＋flex 内 margin 等価により視覚差は最小の想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)