### PR TITLE
プライバシーポリシーのリンクをクリーンURLに

### DIFF
--- a/src/presentation/pages/HomePage.tsx
+++ b/src/presentation/pages/HomePage.tsx
@@ -86,7 +86,7 @@ export function HomePage(): React.ReactElement {
             ISBNを入力
           </Button>
           <Link
-            href="/privacy-policy.html"
+            href="/privacy-policy"
             target="_blank"
             rel="noopener noreferrer"
             variant="caption"

--- a/src/presentation/pages/LoginPage.tsx
+++ b/src/presentation/pages/LoginPage.tsx
@@ -31,7 +31,7 @@ export function LoginPage(): JSX.Element {
       <Typography variant="caption" color="text.secondary">
         続行すると
         <Link
-          href="/privacy-policy.html"
+          href="/privacy-policy"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
Cloudflare Pages の clean-URL 仕様で `/privacy-policy.html` は `/privacy-policy` へ 308 する。アプリ内リンクを最終 URL に直し、リダイレクト1ホップを回避する。挙動は同じ（表示できる）。

## Test Plan
- [x] tsc 緑
- [x] 本番 `/privacy-policy` が 200/HTML で表示済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)