### PR TITLE
プライバシーポリシーのリンクを .html に戻す（ローカル404修正）

### DIFF
--- a/src/presentation/pages/HomePage.tsx
+++ b/src/presentation/pages/HomePage.tsx
@@ -86,7 +86,7 @@ export function HomePage(): React.ReactElement {
             ISBNを入力
           </Button>
           <Link
-            href="/privacy-policy"
+            href="/privacy-policy.html"
             target="_blank"
             rel="noopener noreferrer"
             variant="caption"

--- a/src/presentation/pages/LoginPage.tsx
+++ b/src/presentation/pages/LoginPage.tsx
@@ -31,7 +31,7 @@ export function LoginPage(): JSX.Element {
       <Typography variant="caption" color="text.secondary">
         続行すると
         <Link
-          href="/privacy-policy"
+          href="/privacy-policy.html"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
クリーンURL `/privacy-policy` は Cloudflare Pages 本番のみの機能で、ローカル Vite dev では 404 になっていた（#104 の副作用）。`/privacy-policy.html` は dev で実ファイル配信・本番では 308 で `/privacy-policy` に追従するため両環境で動作する。

## Test Plan
- [x] tsc 緑
- [x] 本番 `/privacy-policy.html` は 200（308→/privacy-policy）、dev は public 実ファイルで 200