### PR TITLE
利用規約(Terms of Service)を作成しアプリから参照可能に（#109）

### DIFF
--- a/public/terms.html
+++ b/public/terms.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>利用規約 - LibCheck</title>
+  <style>
+    body {
+      font-family: 'BIZ UDGothic', 'Hiragino Sans', 'Noto Sans JP', sans-serif;
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 24px 16px;
+      color: #333;
+      line-height: 1.8;
+    }
+    h1 {
+      font-size: 1.6rem;
+      border-bottom: 2px solid #00796B;
+      padding-bottom: 8px;
+      color: #1a1a2e;
+    }
+    h2 {
+      font-size: 1.2rem;
+      margin-top: 2rem;
+      color: #1a1a2e;
+    }
+    p, li {
+      font-size: 0.95rem;
+    }
+    ul {
+      padding-left: 1.4em;
+    }
+    .last-updated {
+      font-size: 0.85rem;
+      color: #666;
+      margin-bottom: 2rem;
+    }
+    .contact {
+      background: #f1f7f6;
+      border-left: 4px solid #00796B;
+      padding: 12px 16px;
+      border-radius: 0 4px 4px 0;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>利用規約</h1>
+  <p class="last-updated">制定日: 2026年6月28日</p>
+
+  <p>
+    本利用規約（以下「本規約」）は、satoryu（以下「開発者」）が提供する Web アプリケーション「LibCheck」
+    （以下「本サービス」）の利用条件を定めるものです。利用者は、本サービスを利用することにより本規約に同意したものとみなされます。
+  </p>
+
+  <h2>1. 本サービスの内容</h2>
+  <p>
+    本サービスは、書籍の ISBN をもとに、利用者が登録した図書館における蔵書の貸出状況を確認できる
+    無償のツールです。蔵書・図書館の情報はカーリル株式会社が提供する
+    <a href="https://calil.jp/doc/api_ref.html">カーリル図書館 API</a> 等の外部サービスに依拠しており、
+    本サービスは「現状有姿」で提供されます。
+  </p>
+
+  <h2>2. アカウント・利用条件</h2>
+  <ul>
+    <li>本サービスの利用には Google アカウントでのログインが必要です。</li>
+    <li>利用者は、自己の責任においてアカウントを管理するものとします。</li>
+    <li>個人情報の取り扱いは <a href="/privacy-policy.html">プライバシーポリシー</a> に従います。</li>
+  </ul>
+
+  <h2>3. 禁止事項</h2>
+  <p>利用者は、本サービスの利用にあたり、以下の行為を行ってはなりません。</p>
+  <ul>
+    <li>法令または公序良俗に違反する行為</li>
+    <li>本サービスやサーバー・ネットワークに過度な負荷をかける行為、自動化された大量アクセス</li>
+    <li>本サービスや連携先 API を不正に利用・改変・複製する行為、リバースエンジニアリング</li>
+    <li>他者になりすます行為、他者の権利を侵害する行為</li>
+    <li>本サービスの運営を妨害する行為</li>
+  </ul>
+
+  <h2>4. 外部サービス</h2>
+  <p>
+    本サービスは、カーリル図書館 API・OpenBD（書誌・書影）・Amazon（書影および商品ページへのリンク）等の
+    外部サービスを利用します。これらの情報・可用性は各提供元に依存し、開発者はその正確性・完全性・継続性を保証しません。
+    各サービスの利用にあたっては、各提供元の規約が適用されます。
+  </p>
+  <p>
+    本サービスは、Amazon.co.jp を宣伝しリンクすることによって紹介料を獲得できる
+    Amazon アソシエイト・プログラムの参加者です。
+  </p>
+
+  <h2>5. 知的財産権</h2>
+  <p>
+    本サービスに関する著作権その他の知的財産権は、開発者または正当な権利者に帰属します。
+    書誌情報・書影・図書館情報等の権利は、各提供元に帰属します。
+  </p>
+
+  <h2>6. 免責事項</h2>
+  <ul>
+    <li>本サービスは現状有姿で提供され、特定目的への適合性・正確性・可用性等について明示・黙示を問わず保証しません。</li>
+    <li>蔵書状況・貸出可否などの情報は参考であり、最新性・正確性を保証しません。実際の利用可否は各図書館にご確認ください。</li>
+    <li>開発者は、本サービスの利用または利用不能により生じた損害について、法令で許容される範囲で一切の責任を負いません。</li>
+    <li>本サービスは予告なく内容の変更・中断・終了を行うことがあります。</li>
+  </ul>
+
+  <h2>7. 本規約の変更</h2>
+  <p>
+    開発者は、必要に応じて本規約を変更することがあります。変更後の規約は、本ページに掲載した時点から効力を生じるものとします。
+  </p>
+
+  <h2>8. 準拠法・裁判管轄</h2>
+  <p>
+    本規約は日本法を準拠法とし、本サービスに関して紛争が生じた場合は、開発者の住所地を管轄する裁判所を専属的合意管轄とします。
+  </p>
+
+  <h2>9. お問い合わせ</h2>
+  <div class="contact">
+    <p>本規約に関するご質問・ご意見は、下記の GitHub リポジトリの Issue よりお問い合わせください。</p>
+    <p>
+      <strong>GitHub</strong>:
+      <a href="https://github.com/satoryu/LibCheck/issues">https://github.com/satoryu/LibCheck/issues</a>
+    </p>
+  </div>
+
+</body>
+</html>

--- a/src/presentation/pages/HomePage.tsx
+++ b/src/presentation/pages/HomePage.tsx
@@ -85,16 +85,26 @@ export function HomePage(): React.ReactElement {
           >
             ISBNを入力
           </Button>
-          <Link
-            href="/privacy-policy.html"
-            target="_blank"
-            rel="noopener noreferrer"
-            variant="caption"
-            color="text.secondary"
-            sx={{ mt: 3 }}
-          >
-            プライバシーポリシー
-          </Link>
+          <Box sx={{ mt: 3, display: 'flex', gap: 2 }}>
+            <Link
+              href="/terms.html"
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="caption"
+              color="text.secondary"
+            >
+              利用規約
+            </Link>
+            <Link
+              href="/privacy-policy.html"
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="caption"
+              color="text.secondary"
+            >
+              プライバシーポリシー
+            </Link>
+          </Box>
         </Box>
       </Box>
     </Box>

--- a/src/presentation/pages/LoginPage.tsx
+++ b/src/presentation/pages/LoginPage.tsx
@@ -30,6 +30,10 @@ export function LoginPage(): JSX.Element {
       <GoogleSignInControl oneTap />
       <Typography variant="caption" color="text.secondary">
         続行すると
+        <Link href="/terms.html" target="_blank" rel="noopener noreferrer">
+          利用規約
+        </Link>
+        と
         <Link
           href="/privacy-policy.html"
           target="_blank"


### PR DESCRIPTION
Closes #109

## 概要
一般公開の整備、および Google Auth Platform「ブランディング」の「アプリケーション利用規約 URL」欄に設定するため、利用規約を作成する。プライバシーポリシー(#102)と同方式。

## 変更
- **新規/配信**: `public/terms.html`（`/terms` で配信）。章立て: 適用 / サービス内容（無償・現状有姿）/ アカウント・利用条件 / 禁止事項 / 外部サービス（カーリル・OpenBD・Amazon アソシエイト）/ 知的財産 / 免責 / 変更 / 準拠法・裁判管轄 / 問い合わせ
- **LoginPage**: 同意文を「利用規約とプライバシーポリシーに同意」に
- **HomePage**: 利用規約・プライバシーポリシーのリンクを並置
- リンクは `.html`（dev/prod 両対応・本番は 308→クリーンURL）

## Test Plan
- [x] `dist/terms.html` 生成
- [x] `npx tsc -b` / `npm test` 緑（337）
- [ ] （マージ後）本番 `/terms` が 200 表示、LoginPage/HomePage のリンクが開く
- [ ] （メンテナー）Google「アプリケーション利用規約 URL」に `https://libcheck.pages.dev/terms` を設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)