### PR TITLE
検索履歴に上限(100件)を設け保存が壊れる時限バグを修正（#115）

### DIFF
--- a/src/data/repositories/searchHistoryRepositoryImpl.ts
+++ b/src/data/repositories/searchHistoryRepositoryImpl.ts
@@ -1,5 +1,6 @@
 import {
   type SearchHistoryEntry,
+  MAX_SEARCH_HISTORY_ENTRIES,
   searchHistoryEntryFromJson,
   searchHistoryEntryToJson,
 } from '@/domain/models/searchHistoryEntry';
@@ -7,7 +8,8 @@ import type { LocalStorageRepository } from '@/domain/repositories/localStorageR
 import type { SearchHistoryRepository } from '@/domain/repositories/searchHistoryRepository';
 
 const STORAGE_KEY = 'search_history';
-const MAX_ENTRIES = 100;
+// 上限はドメインルール（サーバ実装と共通。#115）。
+const MAX_ENTRIES = MAX_SEARCH_HISTORY_ENTRIES;
 
 export class SearchHistoryRepositoryImpl implements SearchHistoryRepository {
   private readonly localStorage: LocalStorageRepository;

--- a/src/data/repositories/serverSearchHistoryRepositoryImpl.test.ts
+++ b/src/data/repositories/serverSearchHistoryRepositoryImpl.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import type { SearchHistoryEntry } from '@/domain/models/searchHistoryEntry';
+import { MAX_SEARCH_HISTORY_ENTRIES } from '@/domain/models/searchHistoryEntry';
 import { SearchHistoryApiClient } from '@/data/datasources/searchHistoryApiClient';
 import { ServerSearchHistoryRepositoryImpl } from '@/data/repositories/serverSearchHistoryRepositoryImpl';
 
@@ -63,5 +64,23 @@ describe('ServerSearchHistoryRepositoryImpl', () => {
     // #91: 認証は HttpOnly Cookie が主。トークン null でも例外にしない。
     const repo = new ServerSearchHistoryRepositoryImpl(new FakeApi() as never, () => null);
     await expect(repo.getAll()).resolves.toEqual([]);
+  });
+
+  it('save は上限を超えた古い履歴を切り捨てる（#115）', async () => {
+    // 上限まで満たした状態で 1 件保存 → 件数は上限のまま・新規が先頭・最古が消える。
+    // これが無いと #87 の入力検証（PUT 最大件数）に達した時点で保存が永久に失敗する。
+    const api = new FakeApi();
+    api.list = Array.from({ length: MAX_SEARCH_HISTORY_ENTRIES }, (_, i) =>
+      entry(`isbn-${i}`),
+    );
+    const repo = new ServerSearchHistoryRepositoryImpl(api as never, () => 'tok');
+
+    await repo.save(entry('NEW'));
+
+    const isbns = (await repo.getAll()).map((e) => e.isbn);
+    expect(isbns).toHaveLength(MAX_SEARCH_HISTORY_ENTRIES);
+    expect(isbns[0]).toBe('NEW');
+    // 末尾（最古）だった isbn-99 相当が落ちる
+    expect(isbns).not.toContain(`isbn-${MAX_SEARCH_HISTORY_ENTRIES - 1}`);
   });
 });

--- a/src/data/repositories/serverSearchHistoryRepositoryImpl.ts
+++ b/src/data/repositories/serverSearchHistoryRepositoryImpl.ts
@@ -1,4 +1,5 @@
 import type { SearchHistoryEntry } from '@/domain/models/searchHistoryEntry';
+import { MAX_SEARCH_HISTORY_ENTRIES } from '@/domain/models/searchHistoryEntry';
 import type { SearchHistoryRepository } from '@/domain/repositories/searchHistoryRepository';
 import type { SearchHistoryApiClient } from '@/data/datasources/searchHistoryApiClient';
 import { getAuthToken } from '@/data/datasources/authTokenStore';
@@ -28,8 +29,12 @@ export class ServerSearchHistoryRepositoryImpl
 
   async save(entry: SearchHistoryEntry): Promise<void> {
     const current = await this.getAll();
-    // 同一 ISBN は置き換え、最新を先頭に。
-    const next = [entry, ...current.filter((e) => e.isbn !== entry.isbn)];
+    // 同一 ISBN は置き換え、最新を先頭に。上限超過分は古いものから切り捨てる
+    // （放置すると PUT の件数検証に達した時点で保存が失敗し続ける。#115）。
+    const next = [entry, ...current.filter((e) => e.isbn !== entry.isbn)].slice(
+      0,
+      MAX_SEARCH_HISTORY_ENTRIES,
+    );
     await this.apiClient.saveAll(this.token(), next);
   }
 

--- a/src/domain/models/searchHistoryEntry.ts
+++ b/src/domain/models/searchHistoryEntry.ts
@@ -12,6 +12,13 @@ export interface SearchHistoryEntry {
   libraryStatuses: Record<string, string>;
 }
 
+/**
+ * 保存する検索履歴の上限件数（ドメインルール）。超過分は古いものから切り捨てる。
+ * サーバ永続化は PUT 全置換＋入力検証（件数上限）のため、無制限に増やすと
+ * 上限到達後に保存が失敗し続ける（#115）。
+ */
+export const MAX_SEARCH_HISTORY_ENTRIES = 100;
+
 export function searchHistoryEntryFromJson(
   json: Record<string, unknown>,
 ): SearchHistoryEntry {


### PR DESCRIPTION
Closes #115

## 問題
サーバ版履歴（#74）は「全件取得→先頭追加→全置換 PUT」だが上限が無く、#87 の入力検証（PUT 最大 2000 件）に達すると**以後の履歴保存が永久に 413 で失敗**する時限バグだった。localStorage 版に元々あった `MAX_ENTRIES=100` の移植漏れが原因。

## 対応
- 上限を**ドメイン定数** `MAX_SEARCH_HISTORY_ENTRIES = 100` に昇格（旧ポリシーの思想を踏襲）
- `serverSearchHistoryRepositoryImpl.save` で同一 ISBN 置換＋先頭追加後に `slice(0, 100)`（TDD: 上限到達時に新規が先頭・最古が消える）
- localStorage 版もドメイン定数を参照するよう一本化

## Test Plan
- [x] 上限到達時: 保存成功・件数維持・最古が消える（新規テスト）
- [x] 既存の履歴テスト・全テスト緑 / `npx tsc -b` 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)