### PR TITLE
描画クラッシュ時のフォールバックを追加（#117）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { theme } from '@/theme';
 import { SelectedLibrariesProvider } from '@/presentation/hooks/useSelectedLibraries';
 import { AuthProvider } from '@/presentation/auth/AuthProvider';
 import { AuthGate } from '@/presentation/auth/AuthGate';
+import { AppErrorBoundary } from '@/presentation/widgets/AppErrorBoundary';
 import { googleClientId } from '@/data/datasources/authConfig';
 
 /**
@@ -57,6 +58,8 @@ export function App() {
               '.notistack-SnackbarContainer': { top: '64px !important' },
             }}
           />
+          {/* 描画クラッシュ時の白画面を防ぐ全体フォールバック（#117）。 */}
+          <AppErrorBoundary>
           <SnackbarProvider
             anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
           >
@@ -72,6 +75,7 @@ export function App() {
               )}
             </AuthProvider>
           </SnackbarProvider>
+          </AppErrorBoundary>
         </ThemeProvider>
       </QueryClientProvider>
     </DependenciesProvider>

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -5,6 +5,7 @@ import {
 } from 'react-router-dom';
 
 import { AppShell } from '@/presentation/pages/AppShell';
+import { RouteErrorFallback } from '@/presentation/widgets/AppErrorBoundary';
 import { HomePage } from '@/presentation/pages/HomePage';
 import { LibraryManagementPage } from '@/presentation/pages/LibraryManagementPage';
 import { SearchHistoryPage } from '@/presentation/pages/SearchHistoryPage';
@@ -47,5 +48,9 @@ export const routes: RouteObject[] = [
 ];
 
 export function createAppRouter() {
-  return createBrowserRouter(routes);
+  // 全ルートを pathless な親で包み、ルート描画中の例外を errorElement で受ける
+  // （白画面回避。#117）。URL 構造は変わらない。
+  return createBrowserRouter([
+    { errorElement: <RouteErrorFallback />, children: routes },
+  ]);
 }

--- a/src/presentation/widgets/AppErrorBoundary.test.tsx
+++ b/src/presentation/widgets/AppErrorBoundary.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { AppErrorBoundary } from '@/presentation/widgets/AppErrorBoundary';
+
+function Bomb(): JSX.Element {
+  throw new Error('boom');
+}
+
+describe('AppErrorBoundary', () => {
+  beforeEach(() => {
+    // React が componentDidCatch 経由の例外を console.error に出すため黙らせる。
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('子が正常なら子をそのまま表示する', () => {
+    render(
+      <AppErrorBoundary>
+        <div>APP OK</div>
+      </AppErrorBoundary>,
+    );
+    expect(screen.getByText('APP OK')).toBeInTheDocument();
+  });
+
+  it('子が throw したらフォールバック（再読み込みボタン付き）を表示する', () => {
+    render(
+      <AppErrorBoundary>
+        <Bomb />
+      </AppErrorBoundary>,
+    );
+    expect(screen.getByText(/問題が発生しました/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /再読み込み/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('APP OK')).not.toBeInTheDocument();
+  });
+});

--- a/src/presentation/widgets/AppErrorBoundary.tsx
+++ b/src/presentation/widgets/AppErrorBoundary.tsx
@@ -1,0 +1,91 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+
+interface Props {
+  children: ReactNode;
+}
+interface State {
+  hasError: boolean;
+}
+
+/**
+ * アプリ全体の描画例外を受け止めるフォールバック（#117）。
+ *
+ * これが無いと描画クラッシュ時に無言の白画面になる。エラー境界は
+ * クラスコンポーネントでのみ実装できるため class で書く。
+ * 復帰手段は「再読み込み」（SPA 全体を初期化するのが最も確実）。
+ */
+/** react-router の errorElement 用フォールバック（見た目は境界と共通）。 */
+export function RouteErrorFallback(): JSX.Element {
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+        p: 3,
+        textAlign: 'center',
+      }}
+    >
+      <ErrorOutlineIcon sx={{ fontSize: 48, color: 'error.main' }} />
+      <Typography variant="h6" component="h1">
+        問題が発生しました
+      </Typography>
+      <Typography color="text.secondary" variant="body2">
+        ご不便をおかけしています。再読み込みで復帰できることがあります。
+      </Typography>
+      <Button variant="contained" onClick={() => window.location.reload()}>
+        再読み込み
+      </Button>
+    </Box>
+  );
+}
+
+export class AppErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // 監視サービス導入（#118）まではコンソールに記録するのみ。
+    console.error('[AppErrorBoundary]', error, info.componentStack);
+  }
+
+  render(): ReactNode {
+    if (!this.state.hasError) return this.props.children;
+    return (
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 2,
+          p: 3,
+          textAlign: 'center',
+        }}
+      >
+        <ErrorOutlineIcon sx={{ fontSize: 48, color: 'error.main' }} />
+        <Typography variant="h6" component="h1">
+          問題が発生しました
+        </Typography>
+        <Typography color="text.secondary" variant="body2">
+          ご不便をおかけしています。再読み込みで復帰できることがあります。
+        </Typography>
+        <Button variant="contained" onClick={() => window.location.reload()}>
+          再読み込み
+        </Button>
+      </Box>
+    );
+  }
+}


### PR DESCRIPTION
Closes #117

## 変更
- `AppErrorBoundary`（クラスコンポーネント）でプロバイダツリー全体を包み、描画例外時に**「問題が発生しました」＋再読み込みボタン**を表示（無言の白画面を防止）
- react-router に pathless 親ルートの `errorElement`（`RouteErrorFallback`・同一 UI）を追加し、ルート描画中の例外もカバー
- エラーは監視導入（#118）まで console.error に記録

## Test Plan
- [x] 正常時は子をそのまま表示 / 子が throw でフォールバック＋再読み込みボタン（新規テスト）
- [x] `npx tsc -b` / `npm test` 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)